### PR TITLE
fix: tighten workflow permissions to job-level least privilege

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,14 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-permissions:
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0


### PR DESCRIPTION
## Summary
- codeql.yml: トップレベルを `permissions: {}` に変更し、`analyze` jobに `contents: read` + `security-events: write` をjobレベルで付与
- publish.yml: `build` jobに明示的に `permissions: {}` を追加

Resolves code scanning alerts #19, #21 (TokenPermissions)

## Test plan
- [ ] CodeQL workflow が正常に実行される
- [ ] publish workflow は tag push 時のみ発火するため、mainマージ後に次回リリースで確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフロー設定の内部更新を実施しました。

---

**注記:** このリリースはエンドユーザーに影響を与える機能変更を含みません。内部インフラストラクチャの改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->