### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -70,8 +70,8 @@
 | FileChanged | No | filename (basename) |
 | WorktreeCreate | Yes (exit 2) | — |
 | WorktreeRemove | No | — |
-| PreCompact | No | trigger: `manual\|auto` |
-| PostCompact | No | trigger: `manual\|auto` |
+| PreCompact | No | compaction_trigger: `manual\|auto` |
+| PostCompact | No | compaction_trigger: `manual\|auto` |
 | Elicitation | Yes (exit 2) | mcp_server name |
 | ElicitationResult | Yes (exit 2) | mcp_server name |
 | SessionEnd | No | end_reason: `clear\|resume\|logout\|prompt_input_exit\|bypass_permissions_disabled\|other` |

--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-04-04
+> Snapshot: 2026-04-06
 
 ## Config Location
 
@@ -74,7 +74,7 @@
 | PostCompact | No | trigger: `manual\|auto` |
 | Elicitation | Yes (exit 2) | mcp_server name |
 | ElicitationResult | Yes (exit 2) | mcp_server name |
-| SessionEnd | No | end_reason: `clear\|resume\|logout\|prompt_input_exit\|other` |
+| SessionEnd | No | end_reason: `clear\|resume\|logout\|prompt_input_exit\|bypass_permissions_disabled\|other` |
 
 ## Common Input Fields (all events)
 
@@ -96,6 +96,7 @@
 
 - `source`: `startup|resume|clear|compact`
 - `model`: string
+- `agent_type`: string (optional)
 
 ### InstructionsLoaded
 
@@ -155,16 +156,18 @@
 
 ### WorktreeCreate
 
-- `worktree_name`: string
-- `source_path`: string (optional)
+- `worktree_path`: string
+- `isolation_mode`: string (optional)
 
 ### WorktreeRemove
 
 - `worktree_path`: string
+- `reason`: `session_exit|subagent_finish` (optional)
 
 ### PreCompact / PostCompact
 
-- `trigger`: `manual|auto`
+- `compaction_trigger`: `manual|auto`
+- `summary`: string (optional)
 
 ### Elicitation / ElicitationResult
 
@@ -183,9 +186,13 @@
 - `teammate_name`: string
 - `team_name`: string (optional)
 
+### Stop
+
+- `stop_reason`: `end_turn|max_tokens|tool_use|stop_sequence`
+
 ### SessionEnd
 
-- `end_reason`: `clear|resume|logout|prompt_input_exit|other`
+- `end_reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
 
 ## Common Output Fields
 


### PR DESCRIPTION
## Summary

上流の公式ドキュメントとのスナップショット比較を実施。**Claude Code** のみ差分を検出し、スナップショットを更新。

### 検出された差分 (Claude Code)

| 対象 | 変更内容 |
|------|---------|
| `SessionEnd` matcher | `bypass_permissions_disabled` 値を追加 |
| `SessionStart` input | オプショナル `agent_type` フィールドを追加 |
| `WorktreeCreate` input | `worktree_name` → `worktree_path`、`source_path` → `isolation_mode` にリネーム |
| `WorktreeRemove` input | オプショナル `reason` フィールド追加 (`session_exit\|subagent_finish`) |
| `PreCompact`/`PostCompact` input | `trigger` → `compaction_trigger` にリネーム、オプショナル `summary` フィールド追加 |
| `Stop` input | `stop_reason` フィールド追加 (`end_turn\|max_tokens\|tool_use\|stop_sequence`) |

### 差分なしのツール

- **Cursor**: HTTP 429 (rate limited) のためフェッチ不可、スキップ
- **Codex**: hooks スキーマはまだ未公開のまま (変更なし)
- **OpenCode**: 差分なし
- **Gemini**: 差分なし
- **Cline**: 差分なし
- **Copilot**: 差分なし
- **Kiro**: 差分なし

### 実装への影響

ペイロードフィールドは透過的に pass-through されるため、`src/otel_hooks/` 実装ファイルへの変更は不要。

## Test plan

- [x] `uv run pytest tests/ -v` — 103 passed, 0 failed

https://claude.ai/code/session_018z4kkmMu4rCo2QGaKC4L4c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しいStopイベントを追加しました。
  * セッション開始時にエージェント種別を指定できるようになりました。

* **改善**
  * セッション終了に「権限無効化による終了」理由を追加。
  * ワークツリー作成でパス指定と分離モードに対応。
  * ワークツリー削除に終了理由の追跡を追加。
  * コンパクション処理にトリガー種別と要約情報を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->