### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/README.md
+++ b/docs/upstream-specs/README.md
@@ -7,7 +7,7 @@
 
 | File | Source | Snapshot |
 |------|--------|----------|
-| [claude.md](claude.md) | https://code.claude.com/docs/en/hooks | 2026-04-04 |
+| [claude.md](claude.md) | https://code.claude.com/docs/en/hooks | 2026-04-13 |
 | [cursor.md](cursor.md) | https://cursor.com/ja/docs/hooks | 2026-04-04 |
 | [codex.md](codex.md) | https://developers.openai.com/codex/config-reference | 2026-04-04 |
 | [opencode.md](opencode.md) | https://opencode.ai/docs/plugins/ | 2026-04-04 |

--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-04-06
+> Snapshot: 2026-04-13
 
 ## Config Location
 
@@ -65,16 +65,16 @@
 | Stop | Yes (exit 2) | — |
 | StopFailure | No | error_type |
 | TeammateIdle | Yes (exit 2) | — |
-| ConfigChange | Yes (exit 2) | config_source |
+| ConfigChange | Yes (exit 2) | source |
 | CwdChanged | No | — |
 | FileChanged | No | filename (basename) |
 | WorktreeCreate | Yes (exit 2) | — |
 | WorktreeRemove | No | — |
-| PreCompact | No | compaction_trigger: `manual\|auto` |
-| PostCompact | No | compaction_trigger: `manual\|auto` |
+| PreCompact | No | compaction_type: `manual\|auto` |
+| PostCompact | No | compaction_type: `manual\|auto` |
 | Elicitation | Yes (exit 2) | mcp_server name |
 | ElicitationResult | Yes (exit 2) | mcp_server name |
-| SessionEnd | No | end_reason: `clear\|resume\|logout\|prompt_input_exit\|bypass_permissions_disabled\|other` |
+| SessionEnd | No | reason: `clear\|resume\|logout\|prompt_input_exit\|bypass_permissions_disabled\|other` |
 
 ## Common Input Fields (all events)
 
@@ -136,13 +136,21 @@
 - `agent_transcript_path`: string (SubagentStop)
 - `last_assistant_message`: string (SubagentStop)
 
-### TaskCreated / TaskCompleted
+### TaskCreated
 
 - `task_id`: string
 - `task_subject`: string
 - `task_description`: string (optional)
 - `teammate_name`: string (optional)
 - `team_name`: string (optional)
+
+### TaskCompleted
+
+- `task_id`: string
+
+### CwdChanged
+
+- `previous_cwd`: string
 
 ### FileChanged
 
@@ -151,8 +159,7 @@
 
 ### ConfigChange
 
-- `config_source`: `user_settings|project_settings|local_settings|policy_settings|skills`
-- `changes`: object (optional)
+- `source`: `user_settings|project_settings|local_settings|policy_settings|skills`
 
 ### WorktreeCreate
 
@@ -166,20 +173,21 @@
 
 ### PreCompact / PostCompact
 
-- `compaction_trigger`: `manual|auto`
-- `summary`: string (optional)
+- `compaction_type`: `manual|auto`
 
-### Elicitation / ElicitationResult
+### Elicitation
 
 - `mcp_server`: string
-- `tool_name`: string
-- `form_fields`: array (Elicitation)
-- `user_response`: object (ElicitationResult)
+- `form.fields`: array of `{ name, label, type, required }`
+
+### ElicitationResult
+
+- `mcp_server`: string
+- `form_response`: object
 
 ### StopFailure
 
 - `error_type`: `rate_limit|authentication_failed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
-- `error_message`: string
 
 ### TeammateIdle
 
@@ -188,11 +196,11 @@
 
 ### Stop
 
-- `stop_reason`: `end_turn|max_tokens|tool_use|stop_sequence`
+(no extra fields)
 
 ### SessionEnd
 
-- `end_reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
+- `reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
 
 ## Common Output Fields
 
@@ -221,7 +229,14 @@
 }
 ```
 
-### UserPromptSubmit / PostToolUse / Stop / TaskCreated / TaskCompleted
+### UserPromptSubmit
+
+- `decision`: `"block"` (optional)
+- `reason`: string
+- `additionalContext`: string (optional)
+- `sessionTitle`: string (optional)
+
+### PostToolUse / Stop / TaskCreated / TaskCompleted
 
 - `decision`: `"block"` (optional)
 - `reason`: string


### PR DESCRIPTION
## Summary

公式ドキュメント（https://code.claude.com/docs/en/hooks）と `docs/upstream-specs/claude.md` を比較し、以下の差分を検出・反映しました。他の7ツール（Cursor/Codex/OpenCode/Gemini/Cline/Copilot/Kiro）は差分なし。

### Claude Code の変更点（スナップショット 2026-04-06 → 2026-04-13）

| カテゴリ | 変更内容 |
|---------|---------|
| **CwdChanged** | 新規フィールド `previous_cwd` 追加 |
| **PreCompact/PostCompact** | `compaction_trigger` → `compaction_type` にリネーム、`summary` フィールド削除 |
| **Elicitation** | `form_fields: array` → `form: { fields: [{name, label, type, required}] }` に構造変更、`tool_name` フィールド削除 |
| **ElicitationResult** | `user_response` → `form_response` にリネーム |
| **TaskCompleted** | TaskCreated から分離、`task_id` のみに（`task_subject` 等削除） |
| **ConfigChange** | `config_source` → `source` にリネーム、`changes` フィールド削除 |
| **SessionEnd** | `end_reason` → `reason` にリネーム |
| **Stop** | `stop_reason` フィールド削除 |
| **StopFailure** | `error_message` フィールド削除 |
| **UserPromptSubmit output** | `additionalContext`、`sessionTitle` フィールド追加 |

### 実装への影響

otel-hooks はペイロードのフィールドを直接参照せず（`session_id`・`transcript_path`・`hook_event_name` のみ使用）、実装ファイルへの変更は不要です。

## Test plan

- [x] `uv run pytest tests/ -v` — 103 passed, 0 failures

https://claude.ai/code/session_01QAvv6ZTUY1i6H8jpzGWaY7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * イベント入出力仕様を更新しました（フィールド名の変更およびスキーマの改善を含む）
  * 複数のイベント定義を整理および簡素化しました
  * ドキュメント スナップショット日付を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->