### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-04-13
+> Snapshot: 2026-04-20
 
 ## Config Location
 
@@ -10,6 +10,8 @@
 | Global | `~/.claude/settings.json` |
 | Project | `.claude/settings.json` |
 | Local | `.claude/settings.local.json` |
+| Plugin | `<plugin_dir>/hooks/hooks.json` (when plugin enabled) |
+| Skill/Agent | Frontmatter in skill/agent definition (component lifetime) |
 
 ## Config Schema
 
@@ -40,10 +42,14 @@
 
 ### Hook Types
 
-- `command` — shell command (`command`, `async`, `shell`)
+- `command` — shell command (`command`, `async`, `asyncRewake`, `shell`)
 - `http` — POST request (`url`, `headers`, `allowedEnvVars`)
 - `prompt` — LLM prompt (`prompt`, `model`)
 - `agent` — agent invocation (`prompt`, `model`)
+
+### command hook: asyncRewake
+
+`asyncRewake: true` — when combined with `async: true`, wakes Claude if the background command exits with code 2.
 
 ## Hook Events (26 total)
 
@@ -155,39 +161,41 @@
 ### FileChanged
 
 - `file_path`: string
-- `change_type`: `modified|created|deleted`
+- `file_name`: string (basename, used as matcher target)
 
 ### ConfigChange
 
-- `source`: `user_settings|project_settings|local_settings|policy_settings|skills`
+- `config_source`: `user_settings|project_settings|local_settings|policy_settings|skills`
 
 ### WorktreeCreate
 
-- `worktree_path`: string
-- `isolation_mode`: string (optional)
+(no extra input fields — hook outputs the worktree path via stdout on exit 0; any non-zero exit fails creation)
 
 ### WorktreeRemove
 
-- `worktree_path`: string
-- `reason`: `session_exit|subagent_finish` (optional)
+(no extra input fields)
 
 ### PreCompact / PostCompact
 
-- `compaction_type`: `manual|auto`
+- `compact_reason`: `manual|auto`
 
 ### Elicitation
 
-- `mcp_server`: string
-- `form.fields`: array of `{ name, label, type, required }`
+- `mcp_server_name`: string
+- `tool_name`: string
+- `form_fields`: array of `{ name, label, type, required }`
 
 ### ElicitationResult
 
-- `mcp_server`: string
-- `form_response`: object
+- `mcp_server_name`: string
+- `tool_name`: string
+- `action`: `accept|decline|cancel`
+- `content`: object (filled values when action=accept)
 
 ### StopFailure
 
 - `error_type`: `rate_limit|authentication_failed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
+- `error_message`: string
 
 ### TeammateIdle
 
@@ -200,7 +208,7 @@
 
 ### SessionEnd
 
-- `reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
+- `end_reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
 
 ## Common Output Fields
 

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,16 +1,19 @@
 # Kiro Hooks Specification
 
-> Source: https://kiro.dev/docs/cli/hooks/
-> Snapshot: 2026-04-04
+> Source: https://kiro.dev/docs/hooks/
+> Snapshot: 2026-04-20
 
 ## Config Location
 
-| Scope | Path |
-|-------|------|
-| Global | `~/.kiro/agents/default.json` |
-| Project | `.kiro/agents/default.json` |
+Hooks are configured via the **Kiro IDE panel** (UI-based, not JSON files).
+Access: "Agent Hooks" section in the Kiro panel, or Command Palette → `Kiro: Open Kiro Hook UI`.
 
-## Hook Events (5 total)
+> Note: The `~/.kiro/agents/default.json` / `.kiro/agents/default.json` paths from earlier
+> versions may still exist but the primary interface is now the UI form.
+
+## Hook Events (8+ total)
+
+### Agent Events (confirmed)
 
 | Event | Description |
 |-------|-------------|
@@ -19,6 +22,14 @@
 | preToolUse | Before tool execution (can block) |
 | postToolUse | After tool execution with results |
 | stop | Assistant finishes responding |
+
+### New Event Categories (UI labels; exact event names TBD)
+
+| Category | UI Label | Description |
+|----------|----------|-------------|
+| File | File Save / File Create / File Delete | File operations trigger |
+| Task | Pre Task Execution / Post Task Execution | Before/after spec task runs |
+| Manual | Manual Trigger | On-demand execution |
 
 ## Common Input Fields (all events)
 
@@ -56,7 +67,7 @@ Additional fields:
 | `@builtin` | Built-in tools only |
 | (no matcher) | All tools |
 
-## Configuration Options
+## Configuration Options (JSON / legacy)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -65,6 +76,19 @@ Additional fields:
 | `cache_ttl_seconds` | number | 0 | Cache successful results (0 = no cache) |
 
 Note: `agentSpawn` hooks are never cached.
+
+## Configuration Options (UI form)
+
+| Field | Description |
+|-------|-------------|
+| `title` | Short identifier for the hook |
+| `description` | Explanation of hook functionality |
+| `event` | Trigger (File Save, Pre Tool Use, Pre Task Execution, Manual, …) |
+| `tool_name` | Tool filter (for Pre/Post Tool Use hooks) |
+| `file_pattern` | Glob pattern (for file event hooks) |
+| `action` | `Ask Kiro` (agent prompt) or `Run Command` (shell) |
+| `instructions` | Prompt text (for Ask Kiro action) |
+| `command` | Shell command (for Run Command action) |
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

差分が検出された2ツールのスナップショットを更新。

### Claude Code (`docs/upstream-specs/claude.md`)

公式ドキュメント (https://code.claude.com/docs/en/hooks) との比較で以下の差分を検出:

**フィールドリネーム:**
- `ConfigChange`: `source` → `config_source`
- `PreCompact` / `PostCompact`: `compaction_type` → `compact_reason`
- `Elicitation`: `mcp_server` → `mcp_server_name`、`form.fields` → `form_fields`、`tool_name` 追加
- `ElicitationResult`: `mcp_server` → `mcp_server_name`、`form_response` → `content`、`tool_name` / `action` を入力フィールドに追加
- `SessionEnd`: `reason` → `end_reason`

**その他の変更:**
- `FileChanged`: `change_type` 削除 → `file_name`（basename）追加
- `WorktreeCreate`: 入力フィールドから `worktree_path` / `isolation_mode` 削除（worktree path は stdout 出力に変更）
- `WorktreeRemove`: 入力フィールドから `worktree_path` / `reason` 削除
- `StopFailure`: `error_message` フィールド追加
- command hook に `asyncRewake` オプション追加
- 新スコープ: Plugin `hooks/hooks.json`、Skill/agent frontmatter

### Kiro (`docs/upstream-specs/kiro.md`)

公式ドキュメント (https://kiro.dev/docs/hooks/) との比較で以下の差分を検出:

- 設定方式が JSON ファイルから **UI ベース**（Kiro パネルのフォーム）に変更
- 新イベントカテゴリ追加: File（save/create/delete）、Task（spec タスク前後）、Manual（手動トリガー）
- UI フォームフィールド: title、description、event、tool_name、file_pattern、action、instructions、command

### 変更なしのツール

- Cline、GitHub Copilot、OpenCode — スナップショットと一致、変更なし
- Cursor、Gemini、Codex — 公式ドキュメント取得不可（接続エラー）のためスキップ

## Test plan

- [x] `uv run pytest tests/ -v` — 103 tests passed

https://claude.ai/code/session_01PLhukN4CBSgd8mHooVu3Yy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* **Documentation**
  * Claude フックの仕様書を更新しました。フックイベントの入力フィールド名を標準化し、`asyncRewake` パラメータを追加しました。
  * Kiro フックの仕様書を更新しました。JSON ファイルベースの設定から UI ベースの「Kiro IDE パネル」への移行を実施し、サポートされるフックトリガーを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->