### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-04-13
+> Snapshot: 2026-04-27
 
 ## Config Location
 
@@ -24,6 +24,7 @@
             "type": "command",
             "command": "string",
             "async": false,
+            "asyncRewake": false,
             "shell": "bash",
             "timeout": 600,
             "statusMessage": "string",
@@ -40,23 +41,26 @@
 
 ### Hook Types
 
-- `command` — shell command (`command`, `async`, `shell`)
+- `command` — shell command (`command`, `async`, `asyncRewake`, `shell`)
 - `http` — POST request (`url`, `headers`, `allowedEnvVars`)
+- `mcp_tool` — MCP tool call (`server`, `tool`, `input` with `${path}` substitution)
 - `prompt` — LLM prompt (`prompt`, `model`)
-- `agent` — agent invocation (`prompt`, `model`)
+- `agent` — agent invocation (`prompt`, `model`) [experimental]
 
-## Hook Events (26 total)
+## Hook Events (28 total)
 
 | Event | Blockable | Matcher Target |
 |-------|-----------|----------------|
 | SessionStart | No | source: `startup\|resume\|clear\|compact` |
 | InstructionsLoaded | No | load_reason: `session_start\|nested_traversal\|path_glob_match\|include\|compact` |
 | UserPromptSubmit | Yes (exit 2) | — |
+| UserPromptExpansion | Yes (exit 2) | command_name |
 | PreToolUse | Yes (exit 2) | tool_name |
 | PermissionRequest | Yes (exit 2) | tool_name |
 | PermissionDenied | No | tool_name |
 | PostToolUse | No | tool_name |
 | PostToolUseFailure | No | tool_name |
+| PostToolBatch | Yes (exit 2) | — |
 | Notification | No | notification_type |
 | SubagentStart | No | agent_type |
 | SubagentStop | Yes (exit 2) | agent_type |
@@ -111,46 +115,56 @@
 
 - `prompt`: string
 
+### UserPromptExpansion
+
+- `expansion_type`: `slash_command|mcp_prompt`
+- `command_name`: string
+- `command_args`: string
+- `command_source`: `plugin|builtin|custom`
+- `prompt`: string (original unexpanded prompt)
+
 ### PreToolUse / PostToolUse / PostToolUseFailure / PermissionRequest / PermissionDenied
 
 - `tool_name`: string
 - `tool_input`: object (tool-specific)
 - `tool_use_id`: string
 - `tool_response`: object (PostToolUse only)
+- `duration_ms`: number (PostToolUse, PostToolUseFailure only)
 - `error`: string (PostToolUseFailure only)
 - `is_interrupt`: boolean (PostToolUseFailure only)
-- `reason`: string (PermissionDenied only)
+- `denial_reason`: string (PermissionDenied only)
 - `permission_suggestions`: array (PermissionRequest only)
+
+### PostToolBatch
+
+- `tool_calls`: array of `{ tool_name, tool_input, tool_response }`
 
 ### Notification
 
 - `message`: string
 - `title`: string (optional)
 - `notification_type`: `permission_prompt|idle_prompt|auth_success|elicitation_dialog`
+- `notification_data`: object (optional)
 
 ### SubagentStart / SubagentStop
 
 - `agent_id`: string
 - `agent_type`: string
-- `stop_hook_active`: boolean (SubagentStop)
-- `agent_transcript_path`: string (SubagentStop)
-- `last_assistant_message`: string (SubagentStop)
 
 ### TaskCreated
 
 - `task_id`: string
-- `task_subject`: string
-- `task_description`: string (optional)
-- `teammate_name`: string (optional)
-- `team_name`: string (optional)
+- `task_description`: string
 
 ### TaskCompleted
 
 - `task_id`: string
+- `task_description`: string
 
 ### CwdChanged
 
 - `previous_cwd`: string
+- `new_cwd`: string
 
 ### FileChanged
 
@@ -159,40 +173,45 @@
 
 ### ConfigChange
 
-- `source`: `user_settings|project_settings|local_settings|policy_settings|skills`
+- `config_source`: `user_settings|project_settings|local_settings|policy_settings|skills`
+- `changed_keys`: string[]
 
 ### WorktreeCreate
 
 - `worktree_path`: string
-- `isolation_mode`: string (optional)
 
 ### WorktreeRemove
 
 - `worktree_path`: string
-- `reason`: `session_exit|subagent_finish` (optional)
 
 ### PreCompact / PostCompact
 
-- `compaction_type`: `manual|auto`
+- `trigger`: `manual|auto`
+- `estimated_removed_turns`: number (PreCompact only)
+- `removed_turns`: number (PostCompact only)
 
 ### Elicitation
 
-- `mcp_server`: string
-- `form.fields`: array of `{ name, label, type, required }`
+- `server_name`: string
+- `tool_name`: string
+- `fields`: array of `{ name, label, type, required, options? }`
 
 ### ElicitationResult
 
-- `mcp_server`: string
-- `form_response`: object
+- `server_name`: string
+- `tool_name`: string
+- `user_action`: `accepted|declined|cancelled`
+- `user_content`: object
 
 ### StopFailure
 
 - `error_type`: `rate_limit|authentication_failed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
+- `error_message`: string
 
 ### TeammateIdle
 
-- `teammate_name`: string
-- `team_name`: string (optional)
+- `agent_type`: string
+- `agent_id`: string
 
 ### Stop
 
@@ -200,7 +219,7 @@
 
 ### SessionEnd
 
-- `reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
+- `end_reason`: `clear|resume|logout|prompt_input_exit|bypass_permissions_disabled|other`
 
 ## Common Output Fields
 
@@ -229,14 +248,14 @@
 }
 ```
 
-### UserPromptSubmit
+### UserPromptSubmit / UserPromptExpansion
 
 - `decision`: `"block"` (optional)
 - `reason`: string
 - `additionalContext`: string (optional)
-- `sessionTitle`: string (optional)
+- `sessionTitle`: string (UserPromptSubmit only, optional)
 
-### PostToolUse / Stop / TaskCreated / TaskCompleted
+### PostToolUse / PostToolBatch / Stop / TaskCreated / TaskCompleted
 
 - `decision`: `"block"` (optional)
 - `reason`: string

--- a/docs/upstream-specs/cline.md
+++ b/docs/upstream-specs/cline.md
@@ -1,7 +1,7 @@
 # Cline Hooks Specification
 
 > Source: https://docs.cline.bot/customization/hooks
-> Snapshot: 2026-04-04
+> Snapshot: 2026-04-27
 
 ## Config Location
 
@@ -54,17 +54,25 @@ Hooks are **executable scripts** (not JSON config):
 ### TaskStart / TaskResume / TaskCancel / TaskComplete
 
 ```json
-{ "taskStart": { "task": "string" } }
+{
+  "taskStart": {
+    "taskMetadata": {
+      "taskId": "string",
+      "ulid": "string",
+      "initialTask": "string"
+    }
+  }
+}
 ```
 
-(Field key matches event name in camelCase)
+(Field key matches event name in camelCase; `taskMetadata` is nested inside)
 
 ### PreToolUse
 
 ```json
 {
   "preToolUse": {
-    "tool": "string",
+    "toolName": "string",
     "parameters": "object"
   }
 }
@@ -75,11 +83,11 @@ Hooks are **executable scripts** (not JSON config):
 ```json
 {
   "postToolUse": {
-    "tool": "string",
+    "toolName": "string",
     "parameters": "object",
     "result": "string",
     "success": "boolean",
-    "durationMs": "number"
+    "executionTimeMs": "number"
   }
 }
 ```
@@ -89,7 +97,8 @@ Hooks are **executable scripts** (not JSON config):
 ```json
 {
   "userPromptSubmit": {
-    "prompt": "string"
+    "prompt": "string",
+    "attachments": ["string"]
   }
 }
 ```
@@ -99,8 +108,14 @@ Hooks are **executable scripts** (not JSON config):
 ```json
 {
   "preCompact": {
-    "conversationLength": "number",
-    "estimatedTokens": "number"
+    "taskId": "string",
+    "ulid": "string",
+    "contextSize": "number",
+    "compactionStrategy": "string",
+    "tokensIn": "number",
+    "tokensOut": "number",
+    "tokensInCache": "number",
+    "tokensOutCache": "number"
   }
 }
 ```

--- a/docs/upstream-specs/codex.md
+++ b/docs/upstream-specs/codex.md
@@ -1,13 +1,20 @@
 # Codex CLI Hooks Specification
 
 > Source: https://developers.openai.com/codex/config-reference
-> Snapshot: 2026-04-04
+> Snapshot: 2026-04-27
 
 ## Config Location
 
 | Scope | Path |
 |-------|------|
 | Global | `~/.codex/config.toml` |
+| Hooks (inline) | `~/.codex/config.toml` under `[hooks]` table |
+| Hooks (external) | `.codex/hooks.json` |
+| Admin-enforced | `requirements.toml` (managed hooks) |
+
+Admin-enforced hook settings in `requirements.toml`:
+- `hooks.managed_dir` (macOS/Linux): absolute path to managed hook scripts
+- `hooks.windows_managed_dir` (Windows): absolute path to managed hook scripts
 
 ## Hooks Feature Status
 
@@ -15,14 +22,41 @@
 
 ```toml
 [features]
-codex_hooks = true  # Enable lifecycle hooks loaded from hooks.json
+codex_hooks = true  # Enable lifecycle hooks
 ```
 
-## Known Details
+## Hooks Config Schema
 
-- Hooks loaded from `hooks.json` (location unspecified beyond filename)
-- No documented event names, payload schemas, or constraints
-- Feature flag required: `features.codex_hooks = true`
+Hooks can be defined inline in `config.toml` or in `.codex/hooks.json` using the same schema:
+
+```json
+{
+  "<EventName>": [
+    {
+      "matcher": "string",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "string"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Note: Only `command` hook handlers are currently executed; `prompt` and `agent` types are parsed but skipped.
+
+## Documented Hook Events (6)
+
+| Event | Description |
+|-------|-------------|
+| `SessionStart` | Session begins |
+| `UserPromptSubmit` | User submits a prompt |
+| `PreToolUse` | Before tool execution |
+| `PostToolUse` | After tool execution |
+| `PermissionRequest` | Permission dialog appears |
+| `Stop` | Assistant finishes responding |
 
 ## otel-hooks Integration
 
@@ -31,11 +65,12 @@ otel-hooks uses Codex's native OTEL exporter configuration instead of hooks:
 ```toml
 [otel]
 # OTLP exporter settings configured directly in config.toml
+exporter = { "otlp-http" = { endpoint = "https://...", protocol = "json" } }
 ```
 
 Supports `otlp-http` and `otlp-grpc` exporters.
 
 ## TODO
 
-- [ ] Monitor for hooks.json schema documentation
+- [ ] Monitor for full hooks.json payload schema documentation
 - [ ] Track feature graduation from experimental

--- a/docs/upstream-specs/gemini.md
+++ b/docs/upstream-specs/gemini.md
@@ -1,7 +1,7 @@
 # Gemini CLI Hooks Specification
 
 > Source: https://geminicli.com/docs/hooks/
-> Snapshot: 2026-04-04
+> Snapshot: 2026-04-27
 
 ## Config Location
 
@@ -74,6 +74,7 @@ Precedence: Project > Global > System > Extensions
 ## Environment Variables
 
 - `GEMINI_PROJECT_DIR` — project root
+- `GEMINI_PLANS_DIR` — plans directory path
 - `GEMINI_SESSION_ID` — session identifier
 - `GEMINI_CWD` — current working directory
 - `CLAUDE_PROJECT_DIR` — alias for compatibility

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -47,10 +47,13 @@ class HookEvent:
 _METRIC_EVENT_MAP: dict[str, EventType] = {
     "userPromptSubmitted": EventType.PROMPT_SUBMIT,
     "userPromptSubmit": EventType.PROMPT_SUBMIT,
+    "UserPromptSubmit": EventType.PROMPT_SUBMIT,
+    "UserPromptExpansion": EventType.PROMPT_SUBMIT,
     "preToolUse": EventType.TOOL_START,
     "PreToolUse": EventType.TOOL_START,
     "postToolUse": EventType.TOOL_END,
     "PostToolUse": EventType.TOOL_END,
+    "PostToolBatch": EventType.TOOL_END,
     "sessionEnd": EventType.SESSION_END,
     "SessionEnd": EventType.SESSION_END,
     "stop": EventType.SESSION_END,

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -163,6 +163,34 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.session_id, "g2")
         self.assertEqual(event.transcript_path.name, "gemini.jsonl")
 
+    def test_parse_hook_event_for_claude_user_prompt_expansion(self) -> None:
+        """UserPromptExpansion maps to PROMPT_SUBMIT (new Claude Code event)."""
+        payload = {
+            "source_tool": "claude",
+            "hook_event_name": "UserPromptExpansion",
+            "session_id": "s1",
+            "expansion_type": "slash_command",
+            "command_name": "review",
+            "command_args": "",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "claude")
+        self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
+
+    def test_parse_hook_event_for_claude_post_tool_batch(self) -> None:
+        """PostToolBatch maps to TOOL_END (new Claude Code event)."""
+        payload = {
+            "source_tool": "claude",
+            "hook_event_name": "PostToolBatch",
+            "session_id": "s1",
+            "tool_calls": [{"tool_name": "Read", "tool_input": {}, "tool_response": {}}],
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "claude")
+        self.assertEqual(event.type, EventType.TOOL_END)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

公式ドキュメントと `docs/upstream-specs/` スナップショットを比較し、差分があった 4 ツールを更新。

### Claude Code (`claude.md` + `hook_event.py`)
- **新イベント 2 件**: `UserPromptExpansion`、`PostToolBatch`（合計 26 → 28）
- **新フックタイプ**: `mcp_tool`（MCP ツールをフックハンドラとして呼び出し）
- **新 command hook フィールド**: `asyncRewake`
- **フィールド変更**:
  - `ConfigChange.source` → `config_source` + `changed_keys[]`
  - `PreCompact`/`PostCompact`: `compaction_type` → `trigger`、turns フィールド追加
  - `CwdChanged`: `new_cwd` フィールド追加
  - `PostToolUse`/`PostToolUseFailure`: `duration_ms` フィールド追加
  - `PermissionDenied`: `reason` → `denial_reason`
  - `Notification`: `notification_data` フィールド追加
  - `Elicitation`/`ElicitationResult`: `mcp_server` → `server_name`、フォームフィールド構造変更
  - `TaskCreated`/`TaskCompleted`/`TeammateIdle`: フィールド構成を実態に合わせて更新
  - `SubagentStop`: フィールドを簡略化（`agent_type`/`agent_id` のみ）
  - `WorktreeCreate`: `isolation_mode` フィールド削除

### Codex (`codex.md`)
- hooks の設定場所を明確化: `config.toml` のインラインまたは `.codex/hooks.json`
- 管理者強制フック (`requirements.toml`) のドキュメント追加
- サポート済みイベント 6 件を列挙: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `Stop`

### Gemini (`gemini.md`)
- 環境変数 `GEMINI_PLANS_DIR` を追加

### Cline (`cline.md`)
- `preToolUse.tool` → `preToolUse.toolName`
- `postToolUse.durationMs` → `postToolUse.executionTimeMs`
- `userPromptSubmit` に `attachments[]` フィールド追加
- タスクイベント: `task: string` → `taskMetadata` オブジェクト構造
- `preCompact`: フィールドをトークン数・戦略ベースの構成に更新

### 取得できなかったツール
- **Cursor**, **Copilot**: 503 エラーで取得不可 → スナップショット更新なし
- **Kiro**: 404 エラーで取得不可 → スナップショット更新なし
- **OpenCode**: 差分なし

## Test plan

- [x] `uv run pytest tests/ -v` — 105 tests passed (新規テスト 2 件含む)
  - `test_parse_hook_event_for_claude_user_prompt_expansion`
  - `test_parse_hook_event_for_claude_post_tool_batch`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeYEtKrFFyr8dTfa3GVUWS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * フックイベント仕様書を更新し、新しいイベント型とスキーマ変更を反映しました。
  * Claude、Cline、Codex、Geminiの各仕様ドキュメントを最新版に更新しました。

* **Tests**
  * 新しいイベント型マッピングの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->