### PR TITLE
feat(metrics): emit turn duration, per-message usage, project context

### DIFF
--- a/src/otel_hooks/domain/transcript.py
+++ b/src/otel_hooks/domain/transcript.py
@@ -6,11 +6,19 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 MAX_CHARS_DEFAULT = 20000
+
+_USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
 
 
 @dataclass
@@ -110,6 +118,45 @@ def get_message_id(msg: dict[str, Any]) -> str | None:
         if isinstance(mid, str) and mid:
             return mid
     return None
+
+
+def get_timestamp(msg: dict[str, Any]) -> datetime | None:
+    raw = msg.get("timestamp") if isinstance(msg, dict) else None
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def get_usage(msg: dict[str, Any]) -> dict[str, int]:
+    m = msg.get("message") if isinstance(msg, dict) else None
+    if not isinstance(m, dict):
+        return {}
+    raw = m.get("usage")
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, int] = {}
+    for k in _USAGE_KEYS:
+        v = raw.get(k)
+        if isinstance(v, int):
+            out[k] = v
+    return out
+
+
+def get_cwd(msg: dict[str, Any]) -> str | None:
+    if not isinstance(msg, dict):
+        return None
+    v = msg.get("cwd")
+    return v if isinstance(v, str) and v else None
+
+
+def get_git_branch(msg: dict[str, Any]) -> str | None:
+    if not isinstance(msg, dict):
+        return None
+    v = msg.get("gitBranch")
+    return v if isinstance(v, str) and v else None
 
 
 

--- a/src/otel_hooks/providers/common.py
+++ b/src/otel_hooks/providers/common.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-from otel_hooks.domain.transcript import MAX_CHARS_DEFAULT, Turn, extract_text, get_content, get_model, iter_tool_uses, truncate_text
+from otel_hooks.domain.transcript import (
+    MAX_CHARS_DEFAULT,
+    Turn,
+    extract_text,
+    get_content,
+    get_cwd,
+    get_git_branch,
+    get_model,
+    get_timestamp,
+    get_usage,
+    iter_tool_uses,
+    truncate_text,
+)
 
 
 @dataclass
@@ -20,6 +32,16 @@ class ToolCall:
 
 
 @dataclass
+class AssistantMessageInfo:
+    """Per-assistant-message metrics for granular generation observations."""
+
+    model: str
+    text: str
+    text_meta: dict[str, Any]
+    usage: dict[str, int]
+
+
+@dataclass
 class TurnPayload:
     user_text: str
     user_text_meta: dict[str, Any]
@@ -27,6 +49,11 @@ class TurnPayload:
     assistant_text_meta: dict[str, Any]
     model: str
     tool_calls: list[ToolCall]
+    turn_duration_s: float | None = None
+    usage: dict[str, int] = field(default_factory=dict)
+    assistants: list[AssistantMessageInfo] = field(default_factory=list)
+    cwd: str | None = None
+    git_branch: str | None = None
 
 
 def _tool_calls_from_assistants(assistant_msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -44,6 +71,25 @@ def _tool_calls_from_assistants(assistant_msgs: list[dict[str, Any]]) -> list[di
                 }
             )
     return calls
+
+
+def _aggregate_usage(per_msg: list[dict[str, int]]) -> dict[str, int]:
+    """Sum output_tokens across assistant messages, take MAX of input/cache (monotonic per turn).
+
+    Within a turn, the assistant input grows as tool_results accumulate, so the *peak* input
+    represents that turn's true context-window load. Output tokens are produced incrementally,
+    so they are summed.
+    """
+    if not per_msg:
+        return {}
+    agg: dict[str, int] = {}
+    for u in per_msg:
+        for k, v in u.items():
+            if k == "output_tokens":
+                agg[k] = agg.get(k, 0) + v
+            else:
+                agg[k] = max(agg.get(k, 0), v)
+    return agg
 
 
 def build_turn_payload(turn: Turn, *, max_chars: int = MAX_CHARS_DEFAULT) -> TurnPayload:
@@ -82,6 +128,28 @@ def build_turn_payload(turn: Turn, *, max_chars: int = MAX_CHARS_DEFAULT) -> Tur
             )
         )
 
+    assistants: list[AssistantMessageInfo] = []
+    per_msg_usage: list[dict[str, int]] = []
+    for am in turn.assistant_msgs:
+        usage = get_usage(am)
+        per_msg_usage.append(usage)
+        text_raw = extract_text(get_content(am))
+        text, text_meta = truncate_text(text_raw, max_chars)
+        assistants.append(
+            AssistantMessageInfo(
+                model=get_model(am),
+                text=text,
+                text_meta=text_meta,
+                usage=usage,
+            )
+        )
+
+    user_ts = get_timestamp(turn.user_msg)
+    last_ts = get_timestamp(last_assistant)
+    duration: float | None = None
+    if user_ts and last_ts and last_ts >= user_ts:
+        duration = (last_ts - user_ts).total_seconds()
+
     return TurnPayload(
         user_text=user_text,
         user_text_meta=user_text_meta,
@@ -89,4 +157,9 @@ def build_turn_payload(turn: Turn, *, max_chars: int = MAX_CHARS_DEFAULT) -> Tur
         assistant_text_meta=assistant_text_meta,
         model=model,
         tool_calls=tool_calls,
+        turn_duration_s=duration,
+        usage=_aggregate_usage(per_msg_usage),
+        assistants=assistants,
+        cwd=get_cwd(turn.user_msg),
+        git_branch=get_git_branch(turn.user_msg),
     )

--- a/src/otel_hooks/providers/datadog.py
+++ b/src/otel_hooks/providers/datadog.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from otel_hooks.domain.transcript import MAX_CHARS_DEFAULT, Turn
 from otel_hooks.providers._dd_transport import Tracer
-from otel_hooks.providers.common import build_turn_payload
+from otel_hooks.providers.common import AssistantMessageInfo, build_turn_payload
 
 
 class DatadogProvider:
@@ -28,6 +28,14 @@ class DatadogProvider:
             tags["transcript_path"] = str(transcript_path)
         if source_tool:
             tags["source_tool"] = source_tool
+        if payload.turn_duration_s is not None:
+            tags["turn.duration_seconds"] = str(payload.turn_duration_s)
+        if payload.cwd:
+            tags["cwd"] = payload.cwd
+        if payload.git_branch:
+            tags["git.branch"] = payload.git_branch
+        for k, v in payload.usage.items():
+            tags[f"gen_ai.usage.{k}"] = str(v)
         with self._tracer.trace(
             "ai_session.turn",
             resource=f"{source_tool} - Turn {turn_num}" if source_tool else f"Turn {turn_num}",
@@ -36,20 +44,32 @@ class DatadogProvider:
         ) as root_span:
             root_span.set_tags(tags)
 
-            with self._tracer.trace(
-                "ai_session.generation",
-                resource="Assistant Response",
-                service="otel-hooks",
-                span_type="llm",
-            ) as gen_span:
-                gen_span.set_tags(
-                    {
-                        "gen_ai.request.model": payload.model,
-                        "gen_ai.prompt": payload.user_text,
-                        "gen_ai.completion": payload.assistant_text,
+            assistants = payload.assistants or [
+                AssistantMessageInfo(
+                    model=payload.model,
+                    text=payload.assistant_text,
+                    text_meta=payload.assistant_text_meta,
+                    usage={},
+                )
+            ]
+            for idx, am in enumerate(assistants):
+                with self._tracer.trace(
+                    "ai_session.generation",
+                    resource="Assistant Response",
+                    service="otel-hooks",
+                    span_type="llm",
+                ) as gen_span:
+                    gen_tags: dict[str, str] = {
+                        "gen_ai.request.model": am.model,
+                        "gen_ai.completion": am.text,
+                        "gen_ai.message.index": str(idx),
                         "gen_ai.usage.tool_count": str(len(payload.tool_calls)),
                     }
-                )
+                    if idx == 0:
+                        gen_tags["gen_ai.prompt"] = payload.user_text
+                    for k, v in am.usage.items():
+                        gen_tags[f"gen_ai.usage.{k}"] = str(v)
+                    gen_span.set_tags(gen_tags)
 
             for tc in payload.tool_calls:
                 in_str = tc.input if isinstance(tc.input, str) else json.dumps(tc.input, ensure_ascii=False)

--- a/src/otel_hooks/providers/langfuse.py
+++ b/src/otel_hooks/providers/langfuse.py
@@ -8,7 +8,19 @@ from typing import Any
 from langfuse import Langfuse, propagate_attributes
 
 from otel_hooks.domain.transcript import MAX_CHARS_DEFAULT, Turn
-from otel_hooks.providers.common import build_turn_payload
+from otel_hooks.providers.common import AssistantMessageInfo, build_turn_payload
+
+
+_LF_USAGE_KEY_MAP = {
+    "input_tokens": "input",
+    "output_tokens": "output",
+    "cache_read_input_tokens": "cache_read_input_tokens",
+    "cache_creation_input_tokens": "cache_creation_input_tokens",
+}
+
+
+def _to_langfuse_usage(usage: dict[str, int]) -> dict[str, int]:
+    return {_LF_USAGE_KEY_MAP[k]: v for k, v in usage.items() if k in _LF_USAGE_KEY_MAP}
 
 
 class LangfuseProvider:
@@ -28,6 +40,14 @@ class LangfuseProvider:
             metadata["transcript_path"] = str(transcript_path)
         if source_tool:
             metadata["source_tool"] = source_tool
+        if payload.turn_duration_s is not None:
+            metadata["turn_duration_seconds"] = payload.turn_duration_s
+        if payload.cwd:
+            metadata["cwd"] = payload.cwd
+        if payload.git_branch:
+            metadata["git_branch"] = payload.git_branch
+        if payload.usage:
+            metadata["usage"] = payload.usage
         span_name = f"{source_tool} - Turn {turn_num}" if source_tool else f"AI Session - Turn {turn_num}"
         tags = ["otel-hooks"]
         if source_tool:
@@ -42,18 +62,31 @@ class LangfuseProvider:
                 input={"role": "user", "content": payload.user_text},
                 metadata=metadata,
             ) as trace_span:
-                with self._langfuse.start_as_current_observation(
-                    name="Assistant Response",
-                    as_type="generation",
-                    model=payload.model,
-                    input={"role": "user", "content": payload.user_text},
-                    output={"role": "assistant", "content": payload.assistant_text},
-                    metadata={
-                        "assistant_text": payload.assistant_text_meta,
-                        "tool_count": len(payload.tool_calls),
-                    },
-                ):
-                    pass
+                assistants = payload.assistants or [
+                    AssistantMessageInfo(
+                        model=payload.model,
+                        text=payload.assistant_text,
+                        text_meta=payload.assistant_text_meta,
+                        usage={},
+                    )
+                ]
+                for idx, am in enumerate(assistants):
+                    obs_kwargs: dict[str, Any] = {
+                        "name": "Assistant Response",
+                        "as_type": "generation",
+                        "model": am.model,
+                        "input": {"role": "user", "content": payload.user_text} if idx == 0 else None,
+                        "output": {"role": "assistant", "content": am.text},
+                        "metadata": {
+                            "assistant_text": am.text_meta,
+                            "message_index": idx,
+                            "tool_count": len(payload.tool_calls) if idx == 0 else 0,
+                        },
+                    }
+                    if am.usage:
+                        obs_kwargs["usage_details"] = _to_langfuse_usage(am.usage)
+                    with self._langfuse.start_as_current_observation(**obs_kwargs):
+                        pass
 
                 for tc in payload.tool_calls:
                     with self._langfuse.start_as_current_observation(

--- a/src/otel_hooks/providers/otlp.py
+++ b/src/otel_hooks/providers/otlp.py
@@ -11,7 +11,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from otel_hooks.domain.transcript import MAX_CHARS_DEFAULT, Turn
-from otel_hooks.providers.common import build_turn_payload
+from otel_hooks.providers.common import AssistantMessageInfo, build_turn_payload
 
 
 class OTLPProvider:
@@ -26,7 +26,7 @@ class OTLPProvider:
 
     def emit_turn(self, session_id: str, turn_num: int, turn: Turn, transcript_path: Path | None, source_tool: str = "") -> None:
         payload = build_turn_payload(turn, max_chars=self._max_chars)
-        attrs: dict[str, str | int] = {
+        attrs: dict[str, str | int | float] = {
             "session.id": session_id,
             "gen_ai.system": "otel-hooks",
             "gen_ai.request.model": payload.model,
@@ -37,21 +37,43 @@ class OTLPProvider:
             attrs["transcript_path"] = str(transcript_path)
         if source_tool:
             attrs["source_tool"] = source_tool
+        if payload.turn_duration_s is not None:
+            attrs["turn.duration_seconds"] = payload.turn_duration_s
+        if payload.cwd:
+            attrs["cwd"] = payload.cwd
+        if payload.git_branch:
+            attrs["git.branch"] = payload.git_branch
+        for k, v in payload.usage.items():
+            attrs[f"gen_ai.usage.{k}"] = v
         span_name = f"{source_tool} - Turn {turn_num}" if source_tool else f"AI Session - Turn {turn_num}"
         with self._tracer.start_as_current_span(
             span_name,
             attributes=attrs,
         ):
-            with self._tracer.start_as_current_span(
-                "Assistant Response",
-                attributes={
-                    "gen_ai.request.model": payload.model,
-                    "gen_ai.prompt": payload.user_text,
-                    "gen_ai.completion": payload.assistant_text,
+            assistants = payload.assistants or [
+                AssistantMessageInfo(
+                    model=payload.model,
+                    text=payload.assistant_text,
+                    text_meta=payload.assistant_text_meta,
+                    usage={},
+                )
+            ]
+            for idx, am in enumerate(assistants):
+                gen_attrs: dict[str, str | int | float] = {
+                    "gen_ai.request.model": am.model,
+                    "gen_ai.completion": am.text,
+                    "gen_ai.message.index": idx,
                     "gen_ai.usage.tool_count": len(payload.tool_calls),
-                },
-            ):
-                pass
+                }
+                if idx == 0:
+                    gen_attrs["gen_ai.prompt"] = payload.user_text
+                for k, v in am.usage.items():
+                    gen_attrs[f"gen_ai.usage.{k}"] = v
+                with self._tracer.start_as_current_span(
+                    "Assistant Response",
+                    attributes=gen_attrs,
+                ):
+                    pass
 
             for tc in payload.tool_calls:
                 in_str = tc.input if isinstance(tc.input, str) else json.dumps(tc.input, ensure_ascii=False)

--- a/tests/test_provider_common.py
+++ b/tests/test_provider_common.py
@@ -55,6 +55,87 @@ class ProviderCommonTest(unittest.TestCase):
         self.assertEqual(tool.input, "/tmp/a")
         self.assertEqual(tool.output, '{"ok": true}')
 
+    def test_build_turn_payload_extracts_duration_usage_and_project_context(self) -> None:
+        turn = Turn(
+            user_msg={
+                "type": "user",
+                "timestamp": "2026-04-28T10:00:00Z",
+                "cwd": "/repo/proj",
+                "gitBranch": "feat/x",
+                "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            },
+            assistant_msgs=[
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-04-28T10:00:05Z",
+                    "message": {
+                        "id": "a1",
+                        "role": "assistant",
+                        "model": "claude-x",
+                        "content": [{"type": "tool_use", "id": "t1", "name": "read", "input": {}}],
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 20,
+                            "cache_read_input_tokens": 50,
+                            "cache_creation_input_tokens": 10,
+                        },
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-04-28T10:00:12Z",
+                    "message": {
+                        "id": "a2",
+                        "role": "assistant",
+                        "model": "claude-x",
+                        "content": [{"type": "text", "text": "done"}],
+                        "usage": {
+                            "input_tokens": 200,
+                            "output_tokens": 30,
+                            "cache_read_input_tokens": 80,
+                            "cache_creation_input_tokens": 5,
+                        },
+                    },
+                },
+            ],
+            tool_results_by_id={"t1": "ok"},
+        )
+
+        payload = build_turn_payload(turn)
+
+        self.assertEqual(payload.turn_duration_s, 12.0)
+        self.assertEqual(payload.cwd, "/repo/proj")
+        self.assertEqual(payload.git_branch, "feat/x")
+        # output sums; input/cache take the peak.
+        self.assertEqual(payload.usage["output_tokens"], 50)
+        self.assertEqual(payload.usage["input_tokens"], 200)
+        self.assertEqual(payload.usage["cache_read_input_tokens"], 80)
+        self.assertEqual(payload.usage["cache_creation_input_tokens"], 10)
+        self.assertEqual(len(payload.assistants), 2)
+        self.assertEqual(payload.assistants[0].usage["input_tokens"], 100)
+        self.assertEqual(payload.assistants[1].usage["input_tokens"], 200)
+
+    def test_build_turn_payload_handles_missing_timestamps_and_usage(self) -> None:
+        turn = Turn(
+            user_msg={"message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}},
+            assistant_msgs=[
+                {
+                    "message": {
+                        "id": "a1",
+                        "role": "assistant",
+                        "model": "m",
+                        "content": [{"type": "text", "text": "x"}],
+                    }
+                }
+            ],
+            tool_results_by_id={},
+        )
+        payload = build_turn_payload(turn)
+        self.assertIsNone(payload.turn_duration_s)
+        self.assertEqual(payload.usage, {})
+        self.assertIsNone(payload.cwd)
+        self.assertIsNone(payload.git_branch)
+
     def test_build_turn_payload_truncates_string_fields(self) -> None:
         long = "x" * 25050
         turn = Turn(

--- a/tests/test_providers_contract.py
+++ b/tests/test_providers_contract.py
@@ -15,6 +15,9 @@ def _sample_turn() -> Turn:
     return Turn(
         user_msg={
             "type": "user",
+            "timestamp": "2026-04-28T10:00:00Z",
+            "cwd": "/repo/proj",
+            "gitBranch": "main",
             "message": {
                 "role": "user",
                 "content": [{"type": "text", "text": "hello"}],
@@ -23,6 +26,7 @@ def _sample_turn() -> Turn:
         assistant_msgs=[
             {
                 "type": "assistant",
+                "timestamp": "2026-04-28T10:00:03Z",
                 "message": {
                     "id": "a1",
                     "role": "assistant",
@@ -31,6 +35,12 @@ def _sample_turn() -> Turn:
                         {"type": "tool_use", "id": "t1", "name": "read", "input": {"path": "/tmp/a"}},
                         {"type": "text", "text": "done"},
                     ],
+                    "usage": {
+                        "input_tokens": 11,
+                        "output_tokens": 22,
+                        "cache_read_input_tokens": 33,
+                        "cache_creation_input_tokens": 44,
+                    },
                 },
             }
         ],
@@ -219,8 +229,17 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(client.host, "https://lf")
         self.assertEqual(len(client.spans), 2)
         self.assertEqual(len(client.observations), 2)
-        self.assertEqual(client.spans[0].payload["metadata"]["source_tool"], "claude")
-        self.assertEqual(client.spans[0].payload["metadata"]["transcript_path"], "/tmp/t.jsonl")
+        turn_meta = client.spans[0].payload["metadata"]
+        self.assertEqual(turn_meta["source_tool"], "claude")
+        self.assertEqual(turn_meta["transcript_path"], "/tmp/t.jsonl")
+        self.assertEqual(turn_meta["turn_duration_seconds"], 3.0)
+        self.assertEqual(turn_meta["cwd"], "/repo/proj")
+        self.assertEqual(turn_meta["git_branch"], "main")
+        self.assertEqual(turn_meta["usage"]["input_tokens"], 11)
+        gen_obs = client.observations[0]
+        self.assertEqual(gen_obs.payload["usage_details"]["input"], 11)
+        self.assertEqual(gen_obs.payload["usage_details"]["output"], 22)
+        self.assertEqual(gen_obs.payload["usage_details"]["cache_read_input_tokens"], 33)
         self.assertEqual(client.observations[1].updates[0]["output"], '{"ok": true}')
         self.assertTrue(client.flush_called)
         self.assertTrue(client.shutdown_called)
@@ -242,7 +261,16 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(fake_provider.processors[0].exporter.endpoint, "http://collector")
         self.assertEqual(fake_provider.processors[0].exporter.headers, {"x-auth": "abc"})
         self.assertEqual(spans[0].payload["name"], "claude - Turn 1")
-        self.assertEqual(spans[0].payload["attributes"]["source_tool"], "claude")
+        turn_attrs = spans[0].payload["attributes"]
+        self.assertEqual(turn_attrs["source_tool"], "claude")
+        self.assertEqual(turn_attrs["turn.duration_seconds"], 3.0)
+        self.assertEqual(turn_attrs["cwd"], "/repo/proj")
+        self.assertEqual(turn_attrs["git.branch"], "main")
+        self.assertEqual(turn_attrs["gen_ai.usage.input_tokens"], 11)
+        self.assertEqual(turn_attrs["gen_ai.usage.output_tokens"], 22)
+        gen_attrs = spans[1].payload["attributes"]
+        self.assertEqual(gen_attrs["gen_ai.usage.input_tokens"], 11)
+        self.assertEqual(gen_attrs["gen_ai.message.index"], 0)
         self.assertEqual(spans[2].payload["name"], "Tool: read")
         self.assertEqual(spans[3].payload["name"], "Metric - tool_started")
         self.assertEqual(spans[3].payload["attributes"]["metric.attr.tool_name"], "read")
@@ -262,6 +290,12 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(tracer._global_tags, {"env": "prod"})
         self.assertEqual(spans[0].name, "ai_session.turn")
         self.assertEqual(spans[0].meta["source_tool"], "claude")
+        self.assertEqual(spans[0].meta["turn.duration_seconds"], "3.0")
+        self.assertEqual(spans[0].meta["cwd"], "/repo/proj")
+        self.assertEqual(spans[0].meta["git.branch"], "main")
+        self.assertEqual(spans[0].meta["gen_ai.usage.input_tokens"], "11")
+        self.assertEqual(spans[1].meta["gen_ai.usage.input_tokens"], "11")
+        self.assertEqual(spans[1].meta["gen_ai.message.index"], "0")
         self.assertEqual(spans[2].name, "ai_session.tool")
         self.assertEqual(spans[3].name, "ai_session.metric")
         self.assertEqual(spans[3].meta["metric.attr.tool_name"], "read")


### PR DESCRIPTION
## Why
Three observability signals were sitting in the Claude Code transcript jsonl but never reached providers:

- **Turn duration** — user prompt → final assistant message wall time
- **Per-message context window** — input/output/cache token usage from \`message.usage\`
- **Project context** — \`cwd\` and \`gitBranch\` for group-by

This makes Langfuse cost dashboards stop showing \$0 for Claude sessions and unlocks per-project performance views.

## What

Added to \`TurnPayload\` (non-breaking, all new fields default-initialized):
- \`turn_duration_s: float | None\`
- \`usage: dict[str,int]\` — turn-aggregated (output sums, input/cache take peak)
- \`assistants: list[AssistantMessageInfo]\` — per-message (model + text + usage)
- \`cwd: str | None\`, \`git_branch: str | None\`

Provider behavior:
- **OTLP**: \`gen_ai.usage.{input_tokens,output_tokens,cache_read_input_tokens,cache_creation_input_tokens}\`, \`turn.duration_seconds\`, \`cwd\`, \`git.branch\` on the Turn span. Per-message Generation spans now include \`gen_ai.message.index\` and own \`gen_ai.usage.*\`.
- **Langfuse**: Generation observation gets \`usage_details={input,output,cache_read_input_tokens,cache_creation_input_tokens}\` (drives cost). Turn metadata gets duration / cwd / git_branch / aggregated usage.
- **Datadog**: same as OTLP, stringified per Datadog tag conventions.

The single \"Assistant Response\" emit is now a loop over assistant_msgs, so multi-step tool turns produce one Generation per model call instead of collapsing into the last.

## Tests
\`105 passed\`. New cases:
- \`test_build_turn_payload_extracts_duration_usage_and_project_context\` — duration math, peak vs sum aggregation, per-message info
- \`test_build_turn_payload_handles_missing_timestamps_and_usage\` — graceful no-op on legacy entries
- All three provider contract tests assert the new attrs/tags/metadata are emitted

## Out of scope (next PR)
- Per-tool duration via \`tool_use\` ↔ \`tool_result\` timestamp pairing (requires lifting \`Turn.tool_results_by_id\` from \`id→content\` to a record with timestamp)
- Sidechain (subagent) handling — currently sidechain entries flow into main turns; will isolate in PR#2 with \`tool.subagent_type\` attr for Explore-style measurement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * トレースにターン実行時間を追加
  * トークン使用量メトリクスの詳細記録
  * 環境情報（作業ディレクトリ、Gitブランチ）をキャプチャ
  * アシスタントメッセージごとの詳細情報をトレースに含める

* **Tests**
  * 新メトリクス抽出と集計ロジックの検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->