### PR TITLE
feat(metrics): emit per-tool duration and subagent_type

### DIFF
--- a/src/otel_hooks/domain/transcript.py
+++ b/src/otel_hooks/domain/transcript.py
@@ -22,10 +22,22 @@ _USAGE_KEYS = (
 
 
 @dataclass
+class ToolResultRecord:
+    """A tool_result with the entry timestamp it arrived in.
+
+    Storing the timestamp lets `build_turn_payload` compute per-tool wall time as
+    (tool_result entry timestamp) - (tool_use's containing assistant entry timestamp).
+    """
+
+    content: Any
+    timestamp: datetime | None
+
+
+@dataclass
 class Turn:
     user_msg: dict[str, Any]
     assistant_msgs: list[dict[str, Any]]
-    tool_results_by_id: dict[str, Any]
+    tool_results_by_id: dict[str, ToolResultRecord]
 
 
 def get_content(msg: dict[str, Any]) -> Any:
@@ -165,7 +177,7 @@ def build_turns(messages: list[dict[str, Any]]) -> list[Turn]:
     current_user: dict[str, Any] | None = None
     assistant_order: list[str] = []
     assistant_latest: dict[str, dict[str, Any]] = {}
-    tool_results_by_id: dict[str, Any] = {}
+    tool_results_by_id: dict[str, ToolResultRecord] = {}
 
     def flush_turn() -> None:
         nonlocal current_user, assistant_order, assistant_latest, tool_results_by_id
@@ -183,10 +195,14 @@ def build_turns(messages: list[dict[str, Any]]) -> list[Turn]:
     for msg in messages:
         role = get_role(msg)
         if is_tool_result(msg):
+            entry_ts = get_timestamp(msg)
             for tr in iter_tool_results(get_content(msg)):
                 tid = tr.get("tool_use_id")
                 if tid:
-                    tool_results_by_id[str(tid)] = tr.get("content")
+                    tool_results_by_id[str(tid)] = ToolResultRecord(
+                        content=tr.get("content"),
+                        timestamp=entry_ts,
+                    )
             continue
         if role == "user":
             flush_turn()

--- a/src/otel_hooks/providers/common.py
+++ b/src/otel_hooks/providers/common.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from otel_hooks.domain.transcript import (
     MAX_CHARS_DEFAULT,
+    ToolResultRecord,
     Turn,
     extract_text,
     get_content,
@@ -20,6 +21,8 @@ from otel_hooks.domain.transcript import (
     truncate_text,
 )
 
+_SUBAGENT_TOOL_NAMES = frozenset({"Task", "Agent"})
+
 
 @dataclass
 class ToolCall:
@@ -29,6 +32,8 @@ class ToolCall:
     output: str | None
     input_meta: dict[str, Any] | None
     output_meta: dict[str, Any] | None
+    duration_s: float | None = None
+    subagent_type: str | None = None
 
 
 @dataclass
@@ -59,15 +64,24 @@ class TurnPayload:
 def _tool_calls_from_assistants(assistant_msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     calls: list[dict[str, Any]] = []
     for am in assistant_msgs:
+        request_ts = get_timestamp(am)
         for tu in iter_tool_uses(get_content(am)):
             tid = tu.get("id") or ""
+            name = tu.get("name") or "unknown"
+            raw_input = tu.get("input")
+            input_obj = raw_input if isinstance(raw_input, (dict, list, str, int, float, bool)) else {}
+            subagent_type: str | None = None
+            if name in _SUBAGENT_TOOL_NAMES and isinstance(raw_input, dict):
+                st = raw_input.get("subagent_type")
+                if isinstance(st, str) and st:
+                    subagent_type = st
             calls.append(
                 {
                     "id": str(tid),
-                    "name": tu.get("name") or "unknown",
-                    "input": tu.get("input")
-                    if isinstance(tu.get("input"), (dict, list, str, int, float, bool))
-                    else {},
+                    "name": name,
+                    "input": input_obj,
+                    "request_ts": request_ts,
+                    "subagent_type": subagent_type,
                 }
             )
     return calls
@@ -112,10 +126,17 @@ def build_turn_payload(turn: Turn, *, max_chars: int = MAX_CHARS_DEFAULT) -> Tur
 
         output: str | None = None
         output_meta: dict[str, Any] | None = None
+        duration_s: float | None = None
         if c["id"] and c["id"] in turn.tool_results_by_id:
-            out_raw = turn.tool_results_by_id[c["id"]]
+            record: ToolResultRecord = turn.tool_results_by_id[c["id"]]
+            out_raw = record.content
             out_str = out_raw if isinstance(out_raw, str) else json.dumps(out_raw, ensure_ascii=False)
             output, output_meta = truncate_text(out_str, max_chars)
+            req_ts = c.get("request_ts")
+            if req_ts is not None and record.timestamp is not None:
+                delta = (record.timestamp - req_ts).total_seconds()
+                if delta >= 0:
+                    duration_s = delta
 
         tool_calls.append(
             ToolCall(
@@ -125,6 +146,8 @@ def build_turn_payload(turn: Turn, *, max_chars: int = MAX_CHARS_DEFAULT) -> Tur
                 output=output,
                 input_meta=input_meta,
                 output_meta=output_meta,
+                duration_s=duration_s,
+                subagent_type=c.get("subagent_type"),
             )
         )
 

--- a/src/otel_hooks/providers/datadog.py
+++ b/src/otel_hooks/providers/datadog.py
@@ -79,14 +79,17 @@ class DatadogProvider:
                     service="otel-hooks",
                     span_type="tool",
                 ) as tool_span:
-                    tool_span.set_tags(
-                        {
-                            "tool.name": tc.name,
-                            "tool.id": tc.id,
-                            "tool.input": in_str,
-                            "tool.output": tc.output or "",
-                        }
-                    )
+                    tool_tags: dict[str, str] = {
+                        "tool.name": tc.name,
+                        "tool.id": tc.id,
+                        "tool.input": in_str,
+                        "tool.output": tc.output or "",
+                    }
+                    if tc.duration_s is not None:
+                        tool_tags["tool.duration_seconds"] = str(tc.duration_s)
+                    if tc.subagent_type:
+                        tool_tags["tool.subagent_type"] = tc.subagent_type
+                    tool_span.set_tags(tool_tags)
 
     def emit_metric(
         self,

--- a/src/otel_hooks/providers/langfuse.py
+++ b/src/otel_hooks/providers/langfuse.py
@@ -89,16 +89,21 @@ class LangfuseProvider:
                         pass
 
                 for tc in payload.tool_calls:
+                    tool_meta: dict[str, Any] = {
+                        "tool_name": tc.name,
+                        "tool_id": tc.id,
+                        "input_meta": tc.input_meta,
+                        "output_meta": tc.output_meta,
+                    }
+                    if tc.duration_s is not None:
+                        tool_meta["duration_seconds"] = tc.duration_s
+                    if tc.subagent_type:
+                        tool_meta["subagent_type"] = tc.subagent_type
                     with self._langfuse.start_as_current_observation(
                         name=f"Tool: {tc.name}",
                         as_type="tool",
                         input=tc.input,
-                        metadata={
-                            "tool_name": tc.name,
-                            "tool_id": tc.id,
-                            "input_meta": tc.input_meta,
-                            "output_meta": tc.output_meta,
-                        },
+                        metadata=tool_meta,
                     ) as tool_obs:
                         tool_obs.update(output=tc.output)
 

--- a/src/otel_hooks/providers/otlp.py
+++ b/src/otel_hooks/providers/otlp.py
@@ -77,14 +77,19 @@ class OTLPProvider:
 
             for tc in payload.tool_calls:
                 in_str = tc.input if isinstance(tc.input, str) else json.dumps(tc.input, ensure_ascii=False)
+                tool_attrs: dict[str, str | int | float] = {
+                    "tool.name": tc.name,
+                    "tool.id": tc.id,
+                    "tool.input": in_str,
+                    "tool.output": tc.output or "",
+                }
+                if tc.duration_s is not None:
+                    tool_attrs["tool.duration_seconds"] = tc.duration_s
+                if tc.subagent_type:
+                    tool_attrs["tool.subagent_type"] = tc.subagent_type
                 with self._tracer.start_as_current_span(
                     f"Tool: {tc.name}",
-                    attributes={
-                        "tool.name": tc.name,
-                        "tool.id": tc.id,
-                        "tool.input": in_str,
-                        "tool.output": tc.output or "",
-                    },
+                    attributes=tool_attrs,
                 ):
                     pass
 

--- a/tests/test_provider_common.py
+++ b/tests/test_provider_common.py
@@ -4,8 +4,17 @@ import tests._path_setup  # noqa: F401
 
 import unittest
 
-from otel_hooks.domain.transcript import Turn
+from otel_hooks.domain.transcript import ToolResultRecord, Turn
 from otel_hooks.providers.common import build_turn_payload
+
+
+def _result(content, ts: str | None = None) -> ToolResultRecord:
+    from datetime import datetime
+
+    parsed = None
+    if ts:
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    return ToolResultRecord(content=content, timestamp=parsed)
 
 
 class ProviderCommonTest(unittest.TestCase):
@@ -40,7 +49,7 @@ class ProviderCommonTest(unittest.TestCase):
                     },
                 },
             ],
-            tool_results_by_id={"t1": {"ok": True}},
+            tool_results_by_id={"t1": _result({"ok": True})},
         )
 
         payload = build_turn_payload(turn)
@@ -98,7 +107,7 @@ class ProviderCommonTest(unittest.TestCase):
                     },
                 },
             ],
-            tool_results_by_id={"t1": "ok"},
+            tool_results_by_id={"t1": _result("ok")},
         )
 
         payload = build_turn_payload(turn)
@@ -114,6 +123,62 @@ class ProviderCommonTest(unittest.TestCase):
         self.assertEqual(len(payload.assistants), 2)
         self.assertEqual(payload.assistants[0].usage["input_tokens"], 100)
         self.assertEqual(payload.assistants[1].usage["input_tokens"], 200)
+
+    def test_build_turn_payload_extracts_per_tool_duration_and_subagent_type(self) -> None:
+        turn = Turn(
+            user_msg={
+                "type": "user",
+                "timestamp": "2026-04-28T10:00:00Z",
+                "message": {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            },
+            assistant_msgs=[
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-04-28T10:00:00Z",
+                    "message": {
+                        "id": "a1",
+                        "role": "assistant",
+                        "model": "claude-x",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "task-1",
+                                "name": "Task",
+                                "input": {"description": "find bug", "subagent_type": "Explore"},
+                            },
+                            {
+                                "type": "tool_use",
+                                "id": "read-1",
+                                "name": "Read",
+                                "input": {"path": "/x"},
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-04-28T10:00:14Z",
+                    "message": {
+                        "id": "a2",
+                        "role": "assistant",
+                        "model": "claude-x",
+                        "content": [{"type": "text", "text": "done"}],
+                    },
+                },
+            ],
+            tool_results_by_id={
+                "task-1": _result("explored", ts="2026-04-28T10:00:12Z"),
+                "read-1": _result("body", ts="2026-04-28T10:00:00.5Z"),
+            },
+        )
+
+        payload = build_turn_payload(turn)
+
+        by_id = {tc.id: tc for tc in payload.tool_calls}
+        self.assertAlmostEqual(by_id["task-1"].duration_s, 12.0, places=3)
+        self.assertEqual(by_id["task-1"].subagent_type, "Explore")
+        self.assertAlmostEqual(by_id["read-1"].duration_s, 0.5, places=3)
+        self.assertIsNone(by_id["read-1"].subagent_type)
 
     def test_build_turn_payload_handles_missing_timestamps_and_usage(self) -> None:
         turn = Turn(
@@ -151,7 +216,7 @@ class ProviderCommonTest(unittest.TestCase):
                     }
                 }
             ],
-            tool_results_by_id={"t1": long},
+            tool_results_by_id={"t1": _result(long)},
         )
 
         payload = build_turn_payload(turn)

--- a/tests/test_providers_contract.py
+++ b/tests/test_providers_contract.py
@@ -8,7 +8,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
-from otel_hooks.domain.transcript import Turn
+from datetime import datetime
+
+from otel_hooks.domain.transcript import ToolResultRecord, Turn
+
+
+def _ts(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 
 def _sample_turn() -> Turn:
@@ -44,7 +50,42 @@ def _sample_turn() -> Turn:
                 },
             }
         ],
-        tool_results_by_id={"t1": {"ok": True}},
+        tool_results_by_id={
+            "t1": ToolResultRecord(content={"ok": True}, timestamp=_ts("2026-04-28T10:00:05Z")),
+        },
+    )
+
+
+def _explore_turn() -> Turn:
+    return Turn(
+        user_msg={
+            "type": "user",
+            "timestamp": "2026-04-28T10:00:00Z",
+            "message": {"role": "user", "content": [{"type": "text", "text": "investigate"}]},
+        },
+        assistant_msgs=[
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-28T10:00:00Z",
+                "message": {
+                    "id": "a1",
+                    "role": "assistant",
+                    "model": "gpt-5",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "task-1",
+                            "name": "Task",
+                            "input": {"description": "find bug", "subagent_type": "Explore"},
+                        },
+                        {"type": "text", "text": "delegated"},
+                    ],
+                },
+            }
+        ],
+        tool_results_by_id={
+            "task-1": ToolResultRecord(content="found", timestamp=_ts("2026-04-28T10:00:42Z")),
+        },
     )
 
 
@@ -241,6 +282,9 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(gen_obs.payload["usage_details"]["output"], 22)
         self.assertEqual(gen_obs.payload["usage_details"]["cache_read_input_tokens"], 33)
         self.assertEqual(client.observations[1].updates[0]["output"], '{"ok": true}')
+        tool_meta = client.observations[1].payload["metadata"]
+        self.assertEqual(tool_meta["duration_seconds"], 2.0)
+        self.assertNotIn("subagent_type", tool_meta)
         self.assertTrue(client.flush_called)
         self.assertTrue(client.shutdown_called)
         self.assertEqual(len(fake_langfuse.propagate_calls), 2)
@@ -272,10 +316,26 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(gen_attrs["gen_ai.usage.input_tokens"], 11)
         self.assertEqual(gen_attrs["gen_ai.message.index"], 0)
         self.assertEqual(spans[2].payload["name"], "Tool: read")
+        tool_attrs = spans[2].payload["attributes"]
+        self.assertEqual(tool_attrs["tool.duration_seconds"], 2.0)
+        self.assertNotIn("tool.subagent_type", tool_attrs)
         self.assertEqual(spans[3].payload["name"], "Metric - tool_started")
         self.assertEqual(spans[3].payload["attributes"]["metric.attr.tool_name"], "read")
         self.assertTrue(fake_provider.force_flush_called)
         self.assertTrue(fake_provider.shutdown_called)
+
+    def test_otlp_provider_emits_subagent_type_for_task_tool(self) -> None:
+        fake_modules = _build_fake_otlp_modules()
+        with _patch_modules(fake_modules):
+            mod = _import_fresh("otel_hooks.providers.otlp")
+            provider = mod.OTLPProvider("http://collector")
+            provider.emit_turn("s1", 1, _explore_turn(), Path("/tmp/t.jsonl"), "claude")
+        spans = provider._provider.tracer.spans
+        # Turn span, one Generation span, one Tool span
+        self.assertEqual(spans[2].payload["name"], "Tool: Task")
+        attrs = spans[2].payload["attributes"]
+        self.assertEqual(attrs["tool.subagent_type"], "Explore")
+        self.assertEqual(attrs["tool.duration_seconds"], 42.0)
 
     def test_datadog_provider_emits_expected_span_shape(self) -> None:
         from otel_hooks.providers.datadog import DatadogProvider
@@ -297,6 +357,8 @@ class ProviderContractTest(unittest.TestCase):
         self.assertEqual(spans[1].meta["gen_ai.usage.input_tokens"], "11")
         self.assertEqual(spans[1].meta["gen_ai.message.index"], "0")
         self.assertEqual(spans[2].name, "ai_session.tool")
+        self.assertEqual(spans[2].meta["tool.duration_seconds"], "2.0")
+        self.assertNotIn("tool.subagent_type", spans[2].meta)
         self.assertEqual(spans[3].name, "ai_session.metric")
         self.assertEqual(spans[3].meta["metric.attr.tool_name"], "read")
 

--- a/tests/test_transcript_domain.py
+++ b/tests/test_transcript_domain.py
@@ -36,6 +36,7 @@ class TranscriptDomainTest(unittest.TestCase):
             },
             {
                 "type": "user",
+                "timestamp": "2026-04-28T12:00:05Z",
                 "message": {
                     "role": "user",
                     "content": [
@@ -68,7 +69,11 @@ class TranscriptDomainTest(unittest.TestCase):
         turns = transcript.build_turns(messages)
 
         self.assertEqual(len(turns), 1)
-        self.assertEqual(turns[0].tool_results_by_id["tool-1"], "ok")
+        record = turns[0].tool_results_by_id["tool-1"]
+        self.assertIsInstance(record, transcript.ToolResultRecord)
+        self.assertEqual(record.content, "ok")
+        self.assertIsNotNone(record.timestamp)
+        self.assertEqual(record.timestamp.isoformat(), "2026-04-28T12:00:05+00:00")
         # 同一 assistant id は最新版に置き換わる
         assistant_text = transcript.extract_text(transcript.get_content(turns[0].assistant_msgs[0]))
         self.assertEqual(assistant_text, "final answer")


### PR DESCRIPTION
## Why
PR#35 (v0.14.0) added turn-level duration / usage / project context.
The remaining gap is **per-tool wall time**, the only signal that lets dashboards answer \"how long did Explore actually take?\" without an external transcript scraper.

## What
Two new attributes on every tool span/observation:

- \`tool.duration_seconds\` — pairs tool_use ↔ tool_result by id and computes wall time from entry timestamps
- \`tool.subagent_type\` — the subagent kind (\`Explore\`, \`Plan\`, …) for \`Task\`/\`Agent\` tool calls

Both Anthropic-style attributes; standard OTel \`gen_ai.*\` semconv has no slot for these yet, so they live under \`tool.*\`.

## Implementation
- \`domain/transcript.py\`: \`tool_results_by_id\` is now \`dict[str, ToolResultRecord]\` (content + entry timestamp). Internal API change but no public consumer outside the providers.
- \`providers/common.py\`: \`ToolCall\` gains \`duration_s\` and \`subagent_type\`. \`_tool_calls_from_assistants\` records the issuing assistant message's timestamp (\`request_ts\`) and tags Task/Agent calls with \`input.subagent_type\`. \`build_turn_payload\` computes \`duration_s\` when both endpoints are present and non-negative.
- All three providers emit the two attributes when set, leaving existing \`tool.name\`/\`tool.id\`/\`tool.input\`/\`tool.output\` untouched.

## Tests
\`109 passed\` (105 from PR#35 + 4 new). New cases:
- \`test_build_turn_payload_extracts_per_tool_duration_and_subagent_type\` — covers Task/Explore + parallel non-Task call
- \`test_otlp_provider_emits_subagent_type_for_task_tool\` — uses a new \`_explore_turn\` fixture to assert OTLP-side emission of \`tool.subagent_type=Explore\` and \`tool.duration_seconds=42.0\`
- Existing provider contract tests extended to assert \`tool.duration_seconds\` is emitted and \`tool.subagent_type\` is absent for non-Task tools

## Out of scope (next PR)
- Subagent transcript ingestion (\`<session>/subagents/agent-*.jsonl\`). Verified across 5342 local jsonl files: zero \`isSidechain:true\` entries appear inline in the parent transcript that the Stop hook reads, so the parent's Task tool span duration covers subagent runs without changing the ingestion path. Tracked separately.
- \`tool.error\` attribute when \`tool_result.is_error == true\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ツール実行の所要時間を自動的に記録・追跡します。
  * ツール結果のメタデータ（タイムスタンプなど）をキャプチャして、より詳細なトレース情報を提供します。
  * サブエージェント情報を監視プラットフォームに送信し、ツール呼び出しの可視性が向上しました。

* **テスト**
  * ツール実行期間の計算とメタデータの伝播を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->