### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-04-27
+> Snapshot: 2026-05-04
 
 ## Config Location
 
@@ -47,11 +47,12 @@
 - `prompt` — LLM prompt (`prompt`, `model`)
 - `agent` — agent invocation (`prompt`, `model`) [experimental]
 
-## Hook Events (28 total)
+## Hook Events (29 total)
 
 | Event | Blockable | Matcher Target |
 |-------|-----------|----------------|
 | SessionStart | No | source: `startup\|resume\|clear\|compact` |
+| Setup | No | trigger: `init\|maintenance` |
 | InstructionsLoaded | No | load_reason: `session_start\|nested_traversal\|path_glob_match\|include\|compact` |
 | UserPromptSubmit | Yes (exit 2) | — |
 | UserPromptExpansion | Yes (exit 2) | command_name |
@@ -102,6 +103,10 @@
 - `model`: string
 - `agent_type`: string (optional)
 
+### Setup
+
+- `trigger`: `init|maintenance`
+
 ### InstructionsLoaded
 
 - `file_path`: string
@@ -120,7 +125,7 @@
 - `expansion_type`: `slash_command|mcp_prompt`
 - `command_name`: string
 - `command_args`: string
-- `command_source`: `plugin|builtin|custom`
+- `command_source`: `plugin|project|user`
 - `prompt`: string (original unexpanded prompt)
 
 ### PreToolUse / PostToolUse / PostToolUseFailure / PermissionRequest / PermissionDenied
@@ -291,7 +296,7 @@
 - `$CLAUDE_PLUGIN_ROOT` — plugin install dir
 - `$CLAUDE_PLUGIN_DATA` — plugin data dir
 - `$CLAUDE_CODE_REMOTE` — `"true"` in web environments
-- `$CLAUDE_ENV_FILE` — env persist file (SessionStart, CwdChanged, FileChanged only)
+- `$CLAUDE_ENV_FILE` — env persist file (SessionStart, Setup, CwdChanged, FileChanged only)
 
 ## Constraints
 

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,7 +1,7 @@
 # Kiro Hooks Specification
 
 > Source: https://kiro.dev/docs/cli/hooks/
-> Snapshot: 2026-04-04
+> Snapshot: 2026-05-04
 
 ## Config Location
 
@@ -25,7 +25,8 @@
 ```json
 {
   "hook_event_name": "string",
-  "cwd": "string"
+  "cwd": "string",
+  "session_id": "string"
 }
 ```
 

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -61,6 +61,7 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     # New events from upstream specs
     "sessionStart": EventType.SESSION_START,
     "SessionStart": EventType.SESSION_START,
+    "Setup": EventType.SESSION_START,
     "errorOccurred": EventType.SESSION_END,
     "ErrorOccurred": EventType.SESSION_END,
     "agentSpawn": EventType.SESSION_START,

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -191,6 +191,33 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "claude")
         self.assertEqual(event.type, EventType.TOOL_END)
 
+    def test_parse_hook_event_for_claude_setup_event(self) -> None:
+        """Setup maps to SESSION_START (added in 2026-05-04 spec update)."""
+        payload = {
+            "source_tool": "claude",
+            "hook_event_name": "Setup",
+            "session_id": "s1",
+            "trigger": "init",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "claude")
+        self.assertEqual(event.type, EventType.SESSION_START)
+
+    def test_parse_hook_event_for_kiro_with_session_id(self) -> None:
+        """Kiro payloads now include session_id in common fields (2026-05-04 spec update)."""
+        payload = {
+            "hook_event_name": "userPromptSubmit",
+            "cwd": "/tmp",
+            "session_id": "kiro-sess-1",
+            "prompt": "hello",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
+        self.assertEqual(event.session_id, "kiro-sess-1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "otel-hooks"
-version = "0.13.1"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "langfuse" },


### PR DESCRIPTION
## Summary

公式ドキュメントと `docs/upstream-specs/` スナップショットを比較し、2ツール分の差分を検出・反映しました。

### 検出した差分

**Claude Code** (`docs/upstream-specs/claude.md`, snapshot: 2026-05-04)
- 新規イベント `Setup` を追加 (trigger: `init|maintenance`、28→29イベント)
- `UserPromptExpansion.command_source` の値を更新: `plugin|builtin|custom` → `plugin|project|user`
- `$CLAUDE_ENV_FILE` の利用可能イベントに `Setup` を追加

**Kiro** (`docs/upstream-specs/kiro.md`, snapshot: 2026-05-04)
- コモン入力フィールドに `session_id` を追加（セッション追跡が正式サポート）

差分なし (スキップ): Cursor, Codex, OpenCode, Gemini, Cline, Copilot

### 実装変更

- `src/otel_hooks/hook_event.py`: `_METRIC_EVENT_MAP` に `"Setup": EventType.SESSION_START` を追加
- `tests/test_hook_payload_adapter.py`: `Setup` イベントと Kiro `session_id` のテストを追加 (111 passed)

## Test plan

- [x] `uv run pytest tests/ -v` — 111 passed, 6 subtests passed

https://claude.ai/code/session_01W9apYxYAN8bBYkcp8DKNCJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9apYxYAN8bBYkcp8DKNCJ)_