### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-05-04
+> Snapshot: 2026-05-11
 
 ## Config Location
 
@@ -10,6 +10,8 @@
 | Global | `~/.claude/settings.json` |
 | Project | `.claude/settings.json` |
 | Local | `.claude/settings.local.json` |
+| Plugin | `hooks/hooks.json` (when plugin enabled) |
+| Skill/Agent | Frontmatter (while component active) |
 
 ## Config Schema
 
@@ -90,6 +92,9 @@
   "cwd": "string",
   "permission_mode": "default|plan|acceptEdits|auto|dontAsk|bypassPermissions",
   "hook_event_name": "string",
+  "effort": {
+    "level": "low|medium|high|xhigh|max"
+  },
   "agent_id": "string (subagent only)",
   "agent_type": "string (subagent/--agent only)"
 }
@@ -128,21 +133,29 @@
 - `command_source`: `plugin|project|user`
 - `prompt`: string (original unexpanded prompt)
 
-### PreToolUse / PostToolUse / PostToolUseFailure / PermissionRequest / PermissionDenied
+### PreToolUse / PermissionRequest / PermissionDenied
 
 - `tool_name`: string
 - `tool_input`: object (tool-specific)
 - `tool_use_id`: string
-- `tool_response`: object (PostToolUse only)
-- `duration_ms`: number (PostToolUse, PostToolUseFailure only)
-- `error`: string (PostToolUseFailure only)
-- `is_interrupt`: boolean (PostToolUseFailure only)
-- `denial_reason`: string (PermissionDenied only)
-- `permission_suggestions`: array (PermissionRequest only)
+
+### PostToolUse
+
+- `tool_name`: string
+- `tool_input`: object (tool-specific)
+- `tool_use_id`: string
+- `tool_result`: string
+
+### PostToolUseFailure
+
+- `tool_name`: string
+- `tool_input`: object (tool-specific)
+- `tool_use_id`: string
+- `error`: string
 
 ### PostToolBatch
 
-- `tool_calls`: array of `{ tool_name, tool_input, tool_response }`
+- `tool_uses`: array of `{ tool_name, tool_use_id, tool_input, tool_result?, error? }`
 
 ### Notification
 
@@ -155,20 +168,21 @@
 
 - `agent_id`: string
 - `agent_type`: string
+- `prompt`: string (SubagentStart only)
 
 ### TaskCreated
 
 - `task_id`: string
-- `task_description`: string
+- `task_title`: string (optional)
 
 ### TaskCompleted
 
 - `task_id`: string
-- `task_description`: string
+- `task_title`: string (optional)
 
 ### CwdChanged
 
-- `previous_cwd`: string
+- `old_cwd`: string
 - `new_cwd`: string
 
 ### FileChanged
@@ -179,11 +193,13 @@
 ### ConfigChange
 
 - `config_source`: `user_settings|project_settings|local_settings|policy_settings|skills`
-- `changed_keys`: string[]
+- `file_path`: string
 
 ### WorktreeCreate
 
-- `worktree_path`: string
+- `base_path`: string
+- `worktree_name`: string
+- `ref`: string (optional)
 
 ### WorktreeRemove
 
@@ -210,13 +226,13 @@
 
 ### StopFailure
 
-- `error_type`: `rate_limit|authentication_failed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
+- `error_type`: `rate_limit|authentication_failed|oauth_org_not_allowed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
 - `error_message`: string
 
 ### TeammateIdle
 
+- `teammate_id`: string
 - `agent_type`: string
-- `agent_id`: string
 
 ### Stop
 
@@ -269,13 +285,15 @@
 
 - `hookSpecificOutput.decision.behavior`: `allow|deny`
 - `hookSpecificOutput.decision.updatedInput`: object
-- `hookSpecificOutput.decision.updatedPermissions`: array
-- `hookSpecificOutput.decision.message`: string (deny)
-- `hookSpecificOutput.decision.interrupt`: boolean (deny)
+- `hookSpecificOutput.decision.permissionRules`: array of rule strings
 
 ### PermissionDenied
 
 - `hookSpecificOutput.retry`: boolean
+
+### WorktreeCreate
+
+- `hookSpecificOutput.worktreePath`: string (absolute path)
 
 ### Elicitation / ElicitationResult
 
@@ -296,6 +314,7 @@
 - `$CLAUDE_PLUGIN_ROOT` — plugin install dir
 - `$CLAUDE_PLUGIN_DATA` — plugin data dir
 - `$CLAUDE_CODE_REMOTE` — `"true"` in web environments
+- `$CLAUDE_EFFORT` — effort level (`low`, `medium`, `high`, `xhigh`, `max`)
 - `$CLAUDE_ENV_FILE` — env persist file (SessionStart, Setup, CwdChanged, FileChanged only)
 
 ## Constraints

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,7 +1,7 @@
 # Kiro Hooks Specification
 
 > Source: https://kiro.dev/docs/cli/hooks/
-> Snapshot: 2026-05-04
+> Snapshot: 2026-05-11
 
 ## Config Location
 
@@ -29,6 +29,12 @@
   "session_id": "string"
 }
 ```
+
+## Per-Event Additional Fields
+
+### userPromptSubmit
+
+- `prompt`: string (user's input text)
 
 ## Tool-Related Events (preToolUse, postToolUse)
 

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -179,12 +179,12 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
 
     def test_parse_hook_event_for_claude_post_tool_batch(self) -> None:
-        """PostToolBatch maps to TOOL_END (new Claude Code event)."""
+        """PostToolBatch maps to TOOL_END; tool_uses replaces tool_calls (2026-05-11 spec)."""
         payload = {
             "source_tool": "claude",
             "hook_event_name": "PostToolBatch",
             "session_id": "s1",
-            "tool_calls": [{"tool_name": "Read", "tool_input": {}, "tool_response": {}}],
+            "tool_uses": [{"tool_name": "Read", "tool_use_id": "tu1", "tool_input": {}, "tool_result": "ok"}],
         }
         event = parse_hook_event(payload)
         self.assertIsNotNone(event)


### PR DESCRIPTION
## Summary

Fetched the latest official documentation for all 8 supported tools and compared against `docs/upstream-specs/` snapshots. Differences were found in **Claude Code** (13 changes) and **Kiro** (1 change). The remaining 6 tools (Cursor, OpenCode, Gemini, Cline, Copilot, Codex) had no detectable changes.

### Claude Code — 13 changes (snapshot: 2026-05-04 → 2026-05-11)

| Category | Change |
|----------|--------|
| Common input | New `effort: { level: "low\|medium\|high\|xhigh\|max" }` field added to all events |
| Env vars | New `$CLAUDE_EFFORT` environment variable |
| StopFailure | `error_type` gains `oauth_org_not_allowed` |
| PostToolUse | `tool_response: object` → `tool_result: string`; `duration_ms` removed |
| PostToolUseFailure | `duration_ms` and `is_interrupt` fields removed |
| PostToolBatch | `tool_calls` array → `tool_uses` array; `tool_response` → `tool_result` per entry |
| CwdChanged | `previous_cwd` → `old_cwd` |
| ConfigChange | `changed_keys: string[]` → `file_path: string` |
| TaskCreated/TaskCompleted | `task_description` → `task_title` (optional) |
| SubagentStart | New `prompt: string` field added |
| TeammateIdle | `agent_id` replaced by `teammate_id` |
| WorktreeCreate | Input `worktree_path` → `base_path`, `worktree_name`, `ref` (optional) |
| PermissionRequest output | `updatedPermissions` → `permissionRules` |

### Kiro — 1 change (snapshot: 2026-05-04 → 2026-05-11)

- `userPromptSubmit` event: `prompt: string` field now explicitly documented in per-event section

## Implementation impact

No changes to `src/otel_hooks/` were required. The core event routing in `hook_event.py` is keyed on `hook_event_name` and `session_id`/`transcript_path`; none of the renamed payload fields affect routing logic.

The `PostToolBatch` test in `test_hook_payload_adapter.py` was updated to use the new `tool_uses` field name for accuracy.

## Test plan

- [x] `uv run pytest tests/ -v` — 111 passed, 0 failed

https://claude.ai/code/session_019hCj4WuECKhqac3n6vCn7W

---
_Generated by [Claude Code](https://claude.ai/code/session_019hCj4WuECKhqac3n6vCn7W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Claude Code Hooksの仕様をアップデート。新しい`effort.level`入力フィールドを追加し、複数のイベント構造を更新
  * 環境変数に`$CLAUDE_EFFORT`を追加
  * Kiro Hooksに新しいイベントセクションを追加
  * ドキュメントを最新の仕様（2026-05-11）に更新

* **Tests**
  * 更新された仕様に対応するようテストを更新

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HikaruEgashira/otel-hooks/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->