### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/adr/0003-metrics-tools-must-register-all-observable-events.md
+++ b/docs/adr/0003-metrics-tools-must-register-all-observable-events.md
@@ -9,7 +9,7 @@ Copilot/Kiro は payload adapter 側で複数イベントを `metrics` 化でき
 ## 決定
 `metrics` サポートのツールは、観測可能な全イベントへ `otel-hooks hook` を登録する。
 
-- Copilot: `sessionStart`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `sessionEnd`, `errorOccurred`
+- Copilot: `sessionStart`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `sessionEnd`, `errorOccurred`, `agentStop`, `notification`, `permissionRequest`, `postToolUseFailure`, `preCompact`, `subagentStart`, `subagentStop`
 - Kiro: `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop`
 
 `is_hook_registered` は「全イベントに登録済み」を充足条件とする。

--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-05-11
+> Snapshot: 2026-05-18
 
 ## Config Location
 
@@ -43,13 +43,13 @@
 
 ### Hook Types
 
-- `command` — shell command (`command`, `async`, `asyncRewake`, `shell`)
+- `command` — shell command (`command`, `args`, `async`, `asyncRewake`, `shell`); when `args` present uses exec form (no shell)
 - `http` — POST request (`url`, `headers`, `allowedEnvVars`)
 - `mcp_tool` — MCP tool call (`server`, `tool`, `input` with `${path}` substitution)
 - `prompt` — LLM prompt (`prompt`, `model`)
 - `agent` — agent invocation (`prompt`, `model`) [experimental]
 
-## Hook Events (29 total)
+## Hook Events (30 total)
 
 | Event | Blockable | Matcher Target |
 |-------|-----------|----------------|
@@ -130,7 +130,7 @@
 - `expansion_type`: `slash_command|mcp_prompt`
 - `command_name`: string
 - `command_args`: string
-- `command_source`: `plugin|project|user`
+- `command_source`: `plugin|skill|custom`
 - `prompt`: string (original unexpanded prompt)
 
 ### PreToolUse / PermissionRequest / PermissionDenied
@@ -236,7 +236,8 @@
 
 ### Stop
 
-(no extra fields)
+- `turn_count`: number
+- `message`: string (Claude's final message)
 
 ### SessionEnd
 
@@ -249,7 +250,8 @@
   "continue": true,
   "stopReason": "string",
   "suppressOutput": false,
-  "systemMessage": "string"
+  "systemMessage": "string",
+  "terminalSequence": "string (OSC/BEL escape sequences only)"
 }
 ```
 

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,13 +1,17 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-04-04
+> Snapshot: 2026-05-18
 
 ## Config Location
 
 | Scope | Path |
 |-------|------|
-| Project | `.github/hooks/<name>.json` |
+| Project (repository) | `.github/hooks/<name>.json` |
+| User (CLI) | `~/.copilot/hooks/` |
+
+Cloud Agent: repository only (`.github/hooks/*.json`).
+Cloud agents run in a Linux sandbox; only `bash` and `command` fields honored; network restricted.
 
 ## Config Schema
 
@@ -20,25 +24,45 @@
         "type": "command",
         "bash": "string (script path)",
         "powershell": "string (script path)",
+        "command": "string (cross-platform path)",
         "cwd": "string (optional)",
+        "env": { "<key>": "<value>" },
         "timeoutSec": 30,
         "comment": "string (optional)"
       }
     ]
-  }
+  },
+  "disableAllHooks": true
 }
 ```
 
-## Hook Events (6 total)
+### Hook Types
+
+- `command` — shell script; `bash` (Linux/macOS), `powershell` (Windows), or cross-platform `command`
+- `http` — POST JSON payload; fields: `url`, `headers`, `allowedEnvVars`, `timeoutSec`
+- `prompt` — auto-submit text; fields: `prompt`
+
+### Matcher Filtering
+
+Optional regex patterns supported for: `notification`, `permissionRequest`, `preCompact`, `preToolUse`, `subagentStart`
+
+## Hook Events (13 total)
 
 | Event | Has Output | Description |
 |-------|-----------|-------------|
-| sessionStart | No | New session begins or resumes |
+| sessionStart | No | New or resumed session begins |
 | sessionEnd | No | Session completes or terminates |
 | userPromptSubmitted | No | User submits a prompt |
 | preToolUse | Yes | Before tool execution (can deny) |
 | postToolUse | No | After tool execution |
+| postToolUseFailure | No | After a tool completes with a failure |
 | errorOccurred | No | Error during execution |
+| agentStop | Yes | Main agent finishes a turn (can block) |
+| notification | No | Async system notification (CLI only) |
+| permissionRequest | Yes | Before permission service runs (CLI only) |
+| preCompact | No | Context compaction is about to begin |
+| subagentStart | No | A subagent is spawned (before it runs) |
+| subagentStop | Yes | A subagent completes (can block) |
 
 ## Per-Event Input Schemas
 
@@ -46,6 +70,7 @@
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "source": "new|resume|startup",
@@ -57,6 +82,7 @@
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "reason": "complete|error|abort|timeout|user_exit"
@@ -67,6 +93,7 @@
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "prompt": "string"
@@ -77,6 +104,7 @@
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "toolName": "string",
@@ -88,6 +116,7 @@
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "toolName": "string",
@@ -99,35 +128,115 @@
 }
 ```
 
+### postToolUseFailure
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "toolName": "string",
+  "toolArgs": "string (JSON-stringified)",
+  "error": "string"
+}
+```
+
 ### errorOccurred
 
 ```json
 {
+  "sessionId": "string",
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "error": {
     "message": "string",
     "name": "string",
     "stack": "string (optional)"
-  }
+  },
+  "errorContext": "string",
+  "recoverable": "boolean"
 }
 ```
 
-## preToolUse Output (only event with output)
+### agentStop
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "transcriptPath": "string",
+  "stopReason": "string"
+}
+```
+
+### subagentStart
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string"
+}
+```
+
+### subagentStop
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "transcriptPath": "string",
+  "stopReason": "string"
+}
+```
+
+## Output (events with output)
+
+### preToolUse
 
 ```json
 {
   "permissionDecision": "allow|deny|ask",
-  "permissionDecisionReason": "string"
+  "permissionDecisionReason": "string",
+  "modifiedArgs": "object (optional)"
 }
 ```
 
 Note: only `deny` is processed.
+
+### agentStop / subagentStop
+
+```json
+{
+  "decision": "block|allow",
+  "reason": "string"
+}
+```
+
+### permissionRequest
+
+```json
+{
+  "behavior": "allow|deny",
+  "message": "string",
+  "interrupt": "boolean"
+}
+```
+
+## Exit Codes (command hooks)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — stdout parsed as JSON |
+| 2 | Warning — stderr surfaced but execution continues |
+| Other | Logged failure — execution continues |
 
 ## Constraints
 
 - Default timeout: 30 seconds
 - Multiple hooks of same type execute sequentially
 - Scripts read JSON from stdin
-- Exit code 0 for success
-- No `session_id` or `transcript_path` in payload (metrics-only tool)
+- `disableAllHooks: true` disables all hooks in a file
+- No `transcript_path` in most payloads (metrics-only tool except agentStop/subagentStop)

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -66,6 +66,21 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "ErrorOccurred": EventType.SESSION_END,
     "agentSpawn": EventType.SESSION_START,
     "AgentSpawn": EventType.SESSION_START,
+    # Copilot new events (2026-05-18 spec sync)
+    "agentStop": EventType.SESSION_END,
+    "AgentStop": EventType.SESSION_END,
+    "notification": EventType.SESSION_END,
+    "Notification": EventType.SESSION_END,
+    "permissionRequest": EventType.TOOL_START,
+    "PermissionRequest": EventType.TOOL_START,
+    "postToolUseFailure": EventType.TOOL_END,
+    "PostToolUseFailure": EventType.TOOL_END,
+    "preCompact": EventType.SESSION_END,
+    "PreCompact": EventType.SESSION_END,
+    "subagentStart": EventType.SESSION_START,
+    "SubagentStart": EventType.SESSION_START,
+    "subagentStop": EventType.SESSION_END,
+    "SubagentStop": EventType.SESSION_END,
 }
 
 

--- a/src/otel_hooks/tools/copilot.py
+++ b/src/otel_hooks/tools/copilot.py
@@ -13,7 +13,13 @@ from . import Scope, register_tool
 from .json_io import load_json, save_json
 
 HOOKS_FILE = "otel-hooks.json"
-_HOOK_EVENTS = ("sessionStart", "userPromptSubmitted", "preToolUse", "postToolUse", "sessionEnd", "errorOccurred")
+_HOOK_EVENTS = (
+    "sessionStart", "userPromptSubmitted", "preToolUse", "postToolUse",
+    "sessionEnd", "errorOccurred",
+    # Added in 2026-05-18 spec sync
+    "agentStop", "notification", "permissionRequest", "postToolUseFailure",
+    "preCompact", "subagentStart", "subagentStop",
+)
 _EVENT_ALIASES = {
     "sessionStart": "session_start",
     "SessionStart": "session_start",
@@ -28,6 +34,20 @@ _EVENT_ALIASES = {
     "SessionEnd": "session_end",
     "errorOccurred": "error_occurred",
     "ErrorOccurred": "error_occurred",
+    "agentStop": "agent_stop",
+    "AgentStop": "agent_stop",
+    "notification": "notification",
+    "Notification": "notification",
+    "permissionRequest": "permission_request",
+    "PermissionRequest": "permission_request",
+    "postToolUseFailure": "post_tool_use_failure",
+    "PostToolUseFailure": "post_tool_use_failure",
+    "preCompact": "pre_compact",
+    "PreCompact": "pre_compact",
+    "subagentStart": "subagent_start",
+    "SubagentStart": "subagent_start",
+    "subagentStop": "subagent_stop",
+    "SubagentStop": "subagent_stop",
 }
 
 
@@ -39,9 +59,11 @@ class CopilotConfig:
         return "copilot"
 
     def scopes(self) -> list[Scope]:
-        return [Scope.PROJECT]
+        return [Scope.GLOBAL, Scope.PROJECT]
 
     def settings_path(self, scope: Scope) -> Path:
+        if scope is Scope.GLOBAL:
+            return Path.home() / ".copilot" / "hooks" / HOOKS_FILE
         return Path.cwd() / ".github" / "hooks" / HOOKS_FILE
 
     def load_settings(self, scope: Scope) -> Dict[str, Any]:

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -178,6 +178,60 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "claude")
         self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
 
+    def test_parse_hook_event_for_copilot_agent_stop(self) -> None:
+        """agentStop maps to SESSION_END (new Copilot event, 2026-05-18 spec)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "agentStop",
+            "sessionId": "cp-1",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.SESSION_END)
+        self.assertEqual(event.session_id, "cp-1")
+
+    def test_parse_hook_event_for_copilot_subagent_start(self) -> None:
+        """subagentStart maps to SESSION_START (new Copilot event, 2026-05-18 spec)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "subagentStart",
+            "sessionId": "cp-2",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.SESSION_START)
+
+    def test_parse_hook_event_for_copilot_post_tool_use_failure(self) -> None:
+        """postToolUseFailure maps to TOOL_END (new Copilot event, 2026-05-18 spec)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "postToolUseFailure",
+            "sessionId": "cp-3",
+            "toolName": "bash",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.TOOL_END)
+
+    def test_parse_hook_event_for_copilot_permission_request(self) -> None:
+        """permissionRequest maps to TOOL_START (new Copilot event, 2026-05-18 spec)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "permissionRequest",
+            "sessionId": "cp-4",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.TOOL_START)
+
     def test_parse_hook_event_for_claude_post_tool_batch(self) -> None:
         """PostToolBatch maps to TOOL_END; tool_uses replaces tool_calls (2026-05-11 spec)."""
         payload = {

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -21,7 +21,12 @@ class MetricsHookRegistrationTest(unittest.TestCase):
         updated = cfg.register_hook(settings)
         hooks = updated["hooks"]
 
-        for event_name in ("sessionStart", "userPromptSubmitted", "preToolUse", "postToolUse", "sessionEnd", "errorOccurred"):
+        for event_name in (
+            "sessionStart", "userPromptSubmitted", "preToolUse", "postToolUse",
+            "sessionEnd", "errorOccurred",
+            "agentStop", "notification", "permissionRequest", "postToolUseFailure",
+            "preCompact", "subagentStart", "subagentStop",
+        ):
             self.assertIn(event_name, hooks)
             self.assertTrue(
                 any("otel-hooks hook" in item.get("bash", "") for item in hooks[event_name])
@@ -48,6 +53,13 @@ class MetricsHookRegistrationTest(unittest.TestCase):
                 "postToolUse": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "sessionEnd": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "errorOccurred": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "agentStop": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "notification": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "permissionRequest": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "postToolUseFailure": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "preCompact": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "subagentStart": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "subagentStop": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
             },
         }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

上流公式ドキュメントとスナップショットを比較し、以下の差分を検出・反映しました。

### GitHub Copilot — 大規模変更
- **7つの新規イベントを追加** (6 → 13 イベント):
  - `agentStop` — メインエージェントのターン完了 (ブロック可)
  - `notification` — 非同期システム通知 (CLI限定)
  - `permissionRequest` — パーミッションサービス実行前 (CLI限定)
  - `postToolUseFailure` — ツール失敗後
  - `preCompact` — コンテキスト圧縮前
  - `subagentStart` — サブエージェント生成時
  - `subagentStop` — サブエージェント完了時 (ブロック可)
- **新しいユーザースコープ config**: `~/.copilot/hooks/` (CLI用グローバル)
- **新しい hook types**: HTTP Hooks (`url`, `headers`), Prompt Hooks (`prompt`)
- **`preToolUse` 出力に `modifiedArgs` 追加**
- **共通ペイロードに `sessionId` 追加**

### Claude Code — マイナー変更
- **`Stop` イベントに新フィールド**: `turn_count`, `message`
- **共通出力に `terminalSequence` フィールド追加** (OSC/BELエスケープシーケンス)
- **コマンドフックに `args` フィールド追加** (exec form対応)
- **`UserPromptExpansion` の `command_source` 更新**: `plugin|project|user` → `plugin|skill|custom`
- イベント数を 29 → 30 に更新

### 変更ファイル
- `docs/upstream-specs/copilot.md` — スナップショット更新 (2026-05-18)
- `docs/upstream-specs/claude.md` — スナップショット更新 (2026-05-18)
- `src/otel_hooks/tools/copilot.py` — 7新規イベント登録、グローバルスコープ追加
- `src/otel_hooks/hook_event.py` — 新規 Copilot イベントの EventType マッピング追加
- `docs/adr/0003-metrics-tools-must-register-all-observable-events.md` — Copilot イベントリスト更新
- `tests/test_tools_metrics_registration.py` — 新規イベントのテスト追加
- `tests/test_hook_payload_adapter.py` — 新規 Copilot イベントのペイロードテスト追加

## Test plan

- [x] `uv run pytest tests/ -v` — 115 tests passed

https://claude.ai/code/session_01HU1eBz3VqhVBERb3dYDa2r
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HU1eBz3VqhVBERb3dYDa2r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for additional Copilot hook events (agent stop, permission request, tool use failure, etc.)
  * Enabled global scope configuration for Copilot hooks with home directory settings support
  * Expanded hook payload specifications with enhanced input and output fields

* **Documentation**
  * Updated hook specification documents with clarified Hook Types and event definitions
  * Added new event properties and payload fields to hook specifications
  * Documented configuration scope and constraint details

* **Tests**
  * Added test coverage for new Copilot hook event transformations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HikaruEgashira/otel-hooks/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->