### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-05-18
+> Snapshot: 2026-05-26
 
 ## Config Location
 
@@ -77,8 +77,8 @@
 | FileChanged | No | filename (basename) |
 | WorktreeCreate | Yes (exit 2) | — |
 | WorktreeRemove | No | — |
-| PreCompact | No | compaction_type: `manual\|auto` |
-| PostCompact | No | compaction_type: `manual\|auto` |
+| PreCompact | Yes (exit 2) | trigger: `manual\|auto` |
+| PostCompact | No | trigger: `manual\|auto` |
 | Elicitation | Yes (exit 2) | mcp_server name |
 | ElicitationResult | Yes (exit 2) | mcp_server name |
 | SessionEnd | No | reason: `clear\|resume\|logout\|prompt_input_exit\|bypass_permissions_disabled\|other` |
@@ -130,7 +130,7 @@
 - `expansion_type`: `slash_command|mcp_prompt`
 - `command_name`: string
 - `command_args`: string
-- `command_source`: `plugin|skill|custom`
+- `command_source`: `plugin|user|custom`
 - `prompt`: string (original unexpanded prompt)
 
 ### PreToolUse / PermissionRequest / PermissionDenied
@@ -144,7 +144,7 @@
 - `tool_name`: string
 - `tool_input`: object (tool-specific)
 - `tool_use_id`: string
-- `tool_result`: string
+- `tool_output`: string
 
 ### PostToolUseFailure
 
@@ -155,20 +155,20 @@
 
 ### PostToolBatch
 
-- `tool_uses`: array of `{ tool_name, tool_use_id, tool_input, tool_result?, error? }`
+- `tool_results`: array of `{ tool_name, tool_use_id, tool_input, tool_output?, error? }`
 
 ### Notification
 
 - `message`: string
 - `title`: string (optional)
-- `notification_type`: `permission_prompt|idle_prompt|auth_success|elicitation_dialog`
+- `notification_type`: `permission_prompt|idle_prompt|auth_success|elicitation_dialog|elicitation_complete|elicitation_response`
 - `notification_data`: object (optional)
 
 ### SubagentStart / SubagentStop
 
 - `agent_id`: string
 - `agent_type`: string
-- `prompt`: string (SubagentStart only)
+- `task`: string (SubagentStart only)
 
 ### TaskCreated
 
@@ -182,13 +182,14 @@
 
 ### CwdChanged
 
-- `old_cwd`: string
+- `previous_cwd`: string
 - `new_cwd`: string
 
 ### FileChanged
 
 - `file_path`: string
-- `change_type`: `modified|created|deleted`
+- `file_size`: number
+- `modification_time`: number (Unix seconds)
 
 ### ConfigChange
 
@@ -197,47 +198,48 @@
 
 ### WorktreeCreate
 
-- `base_path`: string
-- `worktree_name`: string
-- `ref`: string (optional)
+- `isolation_type`: `worktree`
+- `subagent_id`: string (optional)
 
 ### WorktreeRemove
 
 - `worktree_path`: string
+- `isolation_type`: `worktree`
+- `subagent_id`: string (optional)
 
 ### PreCompact / PostCompact
 
-- `trigger`: `manual|auto`
-- `estimated_removed_turns`: number (PreCompact only)
-- `removed_turns`: number (PostCompact only)
+- `compaction_trigger`: `manual|auto`
+- `context_used`: number (PreCompact only)
+- `context_limit`: number (PreCompact only)
 
 ### Elicitation
 
-- `server_name`: string
-- `tool_name`: string
-- `fields`: array of `{ name, label, type, required, options? }`
+- `mcp_server_name`: string
+- `request_id`: string
+- `message`: string
+- `form_schema`: object (JSON Schema)
 
 ### ElicitationResult
 
-- `server_name`: string
-- `tool_name`: string
-- `user_action`: `accepted|declined|cancelled`
-- `user_content`: object
+- `mcp_server_name`: string
+- `request_id`: string
+- `action`: `accept|decline|cancel`
+- `content`: object
 
 ### StopFailure
 
-- `error_type`: `rate_limit|authentication_failed|oauth_org_not_allowed|billing_error|invalid_request|server_error|max_output_tokens|unknown`
+- `error_type`: `rate_limit|authentication_failed|oauth_org_not_allowed|billing_error|invalid_request|model_not_found|server_error|max_output_tokens|unknown`
 - `error_message`: string
 
 ### TeammateIdle
 
 - `teammate_id`: string
-- `agent_type`: string
+- `teammate_name`: string
 
 ### Stop
 
-- `turn_count`: number
-- `message`: string (Claude's final message)
+- `assistant_message`: string (Claude's final message)
 
 ### SessionEnd
 
@@ -278,7 +280,7 @@
 - `additionalContext`: string (optional)
 - `sessionTitle`: string (UserPromptSubmit only, optional)
 
-### PostToolUse / PostToolBatch / Stop / TaskCreated / TaskCompleted
+### PostToolUse / PostToolBatch / Stop / TaskCreated / TaskCompleted / PreCompact
 
 - `decision`: `"block"` (optional)
 - `reason`: string

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-05-18
+> Snapshot: 2026-05-26
 
 ## Config Location
 
@@ -176,7 +176,11 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pre
 {
   "sessionId": "string",
   "timestamp": "number (Unix ms)",
-  "cwd": "string"
+  "cwd": "string",
+  "transcriptPath": "string",
+  "agentName": "string",
+  "agentDisplayName": "string (optional)",
+  "agentDescription": "string (optional)"
 }
 ```
 
@@ -188,7 +192,36 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pre
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "transcriptPath": "string",
+  "agentName": "string",
+  "agentDisplayName": "string (optional)",
   "stopReason": "string"
+}
+```
+
+### preCompact
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "transcriptPath": "string",
+  "trigger": "manual|auto",
+  "customInstructions": "string"
+}
+```
+
+### notification
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "hook_event_name": "Notification",
+  "message": "string",
+  "title": "string (optional)",
+  "notification_type": "shell_completed|shell_detached_completed|agent_completed|agent_idle|permission_prompt|elicitation_dialog"
 }
 ```
 
@@ -205,6 +238,18 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pre
 ```
 
 Note: only `deny` is processed.
+
+### postToolUse
+
+```json
+{
+  "modifiedResult": {
+    "resultType": "success",
+    "textResultForLlm": "string"
+  },
+  "additionalContext": "string (optional)"
+}
+```
 
 ### agentStop / subagentStop
 
@@ -239,4 +284,4 @@ Note: only `deny` is processed.
 - Multiple hooks of same type execute sequentially
 - Scripts read JSON from stdin
 - `disableAllHooks: true` disables all hooks in a file
-- No `transcript_path` in most payloads (metrics-only tool except agentStop/subagentStop)
+- `transcriptPath` now included in `agentStop`, `subagentStart`, `subagentStop`, `preCompact`

--- a/docs/upstream-specs/cursor.md
+++ b/docs/upstream-specs/cursor.md
@@ -1,7 +1,7 @@
 # Cursor Hooks Specification
 
 > Source: https://cursor.com/ja/docs/hooks (redirects to https://cursor.com/ja/docs/hooks)
-> Snapshot: 2026-04-04
+> Snapshot: 2026-05-26
 
 ## Config Location
 
@@ -54,7 +54,7 @@ All matching hooks from all sources execute. Conflicts resolved by priority.
 }
 ```
 
-## Hook Events (20 total: 18 Agent + 2 Tab)
+## Hook Events (21 total: 18 Agent + 2 Tab + 1 Lifecycle)
 
 ### Agent Hooks (Cmd+K / Agent Chat)
 
@@ -85,6 +85,12 @@ All matching hooks from all sources execute. Conflicts resolved by priority.
 |-------|-------------|-------------|
 | `beforeTabFileRead` | Yes (allow/deny) | Before Tab reads file |
 | `afterTabFileEdit` | No (observe) | After Tab edits file |
+
+### Lifecycle Hooks (Outside Agent Sessions)
+
+| Event | Controllable | Description |
+|-------|-------------|-------------|
+| `workspaceOpen` | No (fire-and-forget) | Workspace opens; returns plugin paths |
 
 ## Common Input Fields (all events)
 
@@ -358,6 +364,22 @@ All matching hooks from all sources execute. Conflicts resolved by priority.
   }]
 }
 // Output: none
+```
+
+### workspaceOpen
+
+```json
+// Input (omits conversation/generation/model fields)
+{
+  "hook_event_name": "workspaceOpen",
+  "cursor_version": "string",
+  "workspace_roots": ["string"],
+  "user_email": "string|null"
+}
+// Output
+{
+  "pluginPaths": ["string"]
+}
 ```
 
 ### beforeSubmitPrompt

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -233,12 +233,12 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.type, EventType.TOOL_START)
 
     def test_parse_hook_event_for_claude_post_tool_batch(self) -> None:
-        """PostToolBatch maps to TOOL_END; tool_uses replaces tool_calls (2026-05-11 spec)."""
+        """PostToolBatch maps to TOOL_END; tool_results field (2026-05-26 spec)."""
         payload = {
             "source_tool": "claude",
             "hook_event_name": "PostToolBatch",
             "session_id": "s1",
-            "tool_uses": [{"tool_name": "Read", "tool_use_id": "tu1", "tool_input": {}, "tool_result": "ok"}],
+            "tool_results": [{"tool_name": "Read", "tool_use_id": "tu1", "tool_input": {}, "tool_output": "ok"}],
         }
         event = parse_hook_event(payload)
         self.assertIsNotNone(event)


### PR DESCRIPTION
## Summary

Synced `docs/upstream-specs/` snapshots against official upstream documentation (fetched 2026-05-26). Changes detected in **Claude Code**, **Cursor**, and **Copilot**. No changes in Gemini, Kiro, OpenCode, Codex, or Cline.

## Detected Diffs

### Claude Code (2026-05-18 → 2026-05-26)
- `StopFailure.error_type`: added `model_not_found`
- `Notification.notification_type`: added `elicitation_complete`, `elicitation_response`
- `PreCompact`: now blockable (exit 2); field `trigger` → `compaction_trigger`; replaced `estimated_removed_turns` with `context_used`/`context_limit`
- `PostCompact`: `trigger` → `compaction_trigger`; removed `removed_turns`
- `PostToolUse`: `tool_result` → `tool_output`
- `PostToolBatch`: `tool_uses` → `tool_results`; inner `tool_result` → `tool_output`
- `SubagentStart.prompt` → `task`
- `TeammateIdle.agent_type` → `teammate_name`
- `WorktreeCreate`: replaced `base_path`/`worktree_name`/`ref` with `isolation_type`/`subagent_id`
- `WorktreeRemove`: added `isolation_type`, `subagent_id`
- `CwdChanged`: `old_cwd` → `previous_cwd`
- `FileChanged`: removed `change_type`; added `file_size`, `modification_time`
- `Elicitation`: `server_name`/`fields` → `mcp_server_name`/`request_id`/`message`/`form_schema`
- `ElicitationResult`: `user_action`/`user_content` → `action`/`content`
- `UserPromptExpansion.command_source`: value `skill` → `user`
- `Stop`: removed `turn_count`; `message` → `assistant_message`

### Cursor (2026-04-04 → 2026-05-26)
- New lifecycle event `workspaceOpen`: fires outside agent sessions; output `pluginPaths`

### Copilot (2026-05-18 → 2026-05-26)
- `subagentStart`: added `transcriptPath`, `agentName`, `agentDisplayName`, `agentDescription`
- `subagentStop`: added `agentName`, `agentDisplayName`
- `preCompact`: fixed incorrect payload (had `agentStop` fields); now has `trigger`, `customInstructions`, `transcriptPath`
- `notification`: added full input schema with `notification_type` enum values
- `postToolUse` output: added `modifiedResult`, `additionalContext`

## Implementation Impact

No changes to `src/otel_hooks/` were required — the session/transcript detection logic in `hook_event.py` is not affected by the renamed payload fields. The `workspaceOpen` (Cursor) event fires outside agent sessions without a transcript path, so it is documented only.

## Test Changes

- Updated `test_parse_hook_event_for_claude_post_tool_batch` payload to use `tool_results`/`tool_output` (matching 2026-05-26 spec)
- All 115 tests pass

https://claude.ai/code/session_01Uz3LKeZ4cgNHMEUjKhyzSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz3LKeZ4cgNHMEUjKhyzSw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Claude Hook Specification の イベント定義とペイロード構造を更新しました。複数のイベントの入出力フィールドと列挙値が変更されています。
  * Copilot Hook Specification のペイロードスキーマを修正し、各イベントの出力フィールドが拡張されました。
  * Cursor Hook Specification に新しいワークスペース関連イベントを追加しました。

* **Tests**
  * テストケースを新しい仕様に合わせて更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HikaruEgashira/otel-hooks/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->