### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-05-26
+> Snapshot: 2026-06-09
 
 ## Config Location
 
@@ -62,9 +62,10 @@
 | PermissionRequest | Yes (exit 2) | tool_name |
 | PermissionDenied | No | tool_name |
 | PostToolUse | No | tool_name |
-| PostToolUseFailure | No | tool_name |
+| PostToolUseFailure | Yes (exit 2) | tool_name |
 | PostToolBatch | Yes (exit 2) | — |
 | Notification | No | notification_type |
+| MessageDisplay | No | — |
 | SubagentStart | No | agent_type |
 | SubagentStop | Yes (exit 2) | agent_type |
 | TaskCreated | Yes (exit 2) | — |
@@ -182,12 +183,13 @@
 
 ### CwdChanged
 
-- `previous_cwd`: string
+- `old_cwd`: string
 - `new_cwd`: string
 
 ### FileChanged
 
 - `file_path`: string
+- `change_type`: `created|modified|deleted`
 - `file_size`: number
 - `modification_time`: number (Unix seconds)
 
@@ -236,6 +238,10 @@
 
 - `teammate_id`: string
 - `teammate_name`: string
+
+### MessageDisplay
+
+- `text`: string (content being displayed to user)
 
 ### Stop
 
@@ -298,6 +304,10 @@
 ### WorktreeCreate
 
 - `hookSpecificOutput.worktreePath`: string (absolute path)
+
+### MessageDisplay
+
+- `hookSpecificOutput.displayContent`: string (modified display text)
 
 ### Elicitation / ElicitationResult
 

--- a/docs/upstream-specs/codex.md
+++ b/docs/upstream-specs/codex.md
@@ -1,7 +1,7 @@
 # Codex CLI Hooks Specification
 
 > Source: https://developers.openai.com/codex/config-reference
-> Snapshot: 2026-04-27
+> Snapshot: 2026-06-09
 
 ## Config Location
 
@@ -18,11 +18,11 @@ Admin-enforced hook settings in `requirements.toml`:
 
 ## Hooks Feature Status
 
-**Under development; disabled by default.**
+**Gated behind feature flag; disabled by default.**
 
 ```toml
 [features]
-codex_hooks = true  # Enable lifecycle hooks
+hooks = true  # Enable lifecycle hooks
 ```
 
 ## Hooks Config Schema
@@ -47,15 +47,19 @@ Hooks can be defined inline in `config.toml` or in `.codex/hooks.json` using the
 
 Note: Only `command` hook handlers are currently executed; `prompt` and `agent` types are parsed but skipped.
 
-## Documented Hook Events (6)
+## Documented Hook Events (10)
 
 | Event | Description |
 |-------|-------------|
 | `SessionStart` | Session begins |
 | `UserPromptSubmit` | User submits a prompt |
 | `PreToolUse` | Before tool execution |
-| `PostToolUse` | After tool execution |
 | `PermissionRequest` | Permission dialog appears |
+| `PostToolUse` | After tool execution |
+| `PreCompact` | Before history compaction |
+| `PostCompact` | After history compaction |
+| `SubagentStart` | Spawned agent startup |
+| `SubagentStop` | Spawned agent shutdown |
 | `Stop` | Assistant finishes responding |
 
 ## otel-hooks Integration

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,16 +1,21 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-05-26
+> Snapshot: 2026-06-09
 
 ## Config Location
 
+Hooks can be defined in dedicated hook files or inline within settings files:
+
 | Scope | Path |
 |-------|------|
-| Project (repository) | `.github/hooks/<name>.json` |
-| User (CLI) | `~/.copilot/hooks/` |
+| Project (repository) — dedicated file | `.github/hooks/<name>.json` |
+| Project (repository) — inline | `.github/copilot/settings.json` or `.github/copilot/settings.local.json` (under `hooks` key) |
+| User (CLI) — dedicated file | `~/.copilot/hooks/` |
+| User (CLI) — inline | `~/.copilot/settings.json` (under `hooks` key) |
+| Plugin-contributed | `hooks.json` (provided by plugin) |
 
-Cloud Agent: repository only (`.github/hooks/*.json`).
+Cloud Agent: repository files only (`.github/hooks/*.json` and `.github/copilot/settings.json`).
 Cloud agents run in a Linux sandbox; only `bash` and `command` fields honored; network restricted.
 
 ## Config Schema
@@ -153,7 +158,7 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pre
     "name": "string",
     "stack": "string (optional)"
   },
-  "errorContext": "string",
+  "errorContext": "model_call|tool_execution|system|user_input",
   "recoverable": "boolean"
 }
 ```
@@ -278,6 +283,10 @@ Note: only `deny` is processed.
 | 2 | Warning — stderr surfaced but execution continues |
 | Other | Logged failure — execution continues |
 
+## Supported Tool Names (for `preToolUse` matcher)
+
+`ask_user`, `bash`, `create`, `edit`, `glob`, `grep`, `powershell`, `task`, `view`, `web_fetch`
+
 ## Constraints
 
 - Default timeout: 30 seconds
@@ -285,3 +294,4 @@ Note: only `deny` is processed.
 - Scripts read JSON from stdin
 - `disableAllHooks: true` disables all hooks in a file
 - `transcriptPath` now included in `agentStop`, `subagentStart`, `subagentStop`, `preCompact`
+- `preToolUse` is **fail-closed**: crashes, non-zero exits (other than 2), and timeouts all deny the tool call

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -66,6 +66,8 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "ErrorOccurred": EventType.SESSION_END,
     "agentSpawn": EventType.SESSION_START,
     "AgentSpawn": EventType.SESSION_START,
+    # Claude Code new events (2026-06-09 spec sync)
+    "MessageDisplay": EventType.SESSION_END,
     # Copilot new events (2026-05-18 spec sync)
     "agentStop": EventType.SESSION_END,
     "AgentStop": EventType.SESSION_END,

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -258,6 +258,19 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "claude")
         self.assertEqual(event.type, EventType.SESSION_START)
 
+    def test_parse_hook_event_for_claude_message_display(self) -> None:
+        """MessageDisplay maps to SESSION_END (new Claude Code event, 2026-06-09 spec)."""
+        payload = {
+            "source_tool": "claude",
+            "hook_event_name": "MessageDisplay",
+            "session_id": "s1",
+            "text": "Hello from Claude",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "claude")
+        self.assertEqual(event.type, EventType.SESSION_END)
+
     def test_parse_hook_event_for_kiro_with_session_id(self) -> None:
         """Kiro payloads now include session_id in common fields (2026-05-04 spec update)."""
         payload = {


### PR DESCRIPTION
## Summary

公式ドキュメントとスナップショットを比較し、以下の差分を検出・反映しました。

### Claude Code (`docs/upstream-specs/claude.md`)
- **新規イベント `MessageDisplay`** 追加（テキスト表示時に発火、non-blocking）
  - Input: `text: string`
  - Output: `hookSpecificOutput.displayContent: string`
- **`PostToolUseFailure` がブロック可能に変更**（No → Yes, exit 2）
- `CwdChanged` フィールド名変更: `previous_cwd` → `old_cwd`
- `FileChanged` に `change_type: created|modified|deleted` フィールド追加

### Codex (`docs/upstream-specs/codex.md`)
- **新規イベント3件追加**: `PostCompact`, `SubagentStart`, `SubagentStop`（計6→10イベント）
- フィーチャーフラグ変更: `codex_hooks = true` → `hooks = true`

### Copilot (`docs/upstream-specs/copilot.md`)
- **設定ファイルパス追加**: `.github/copilot/settings.json` および `~/.copilot/settings.json` のインラインフック、プラグイン提供 `hooks.json`
- **`preToolUse` の fail-closed 動作を明記**: クラッシュ・タイムアウト・0以外の終了コード（2以外）はすべてツール呼び出しを拒否
- **マッチャー用ツール名リスト追加**: `ask_user`, `bash`, `create`, `edit`, `glob`, `grep`, `powershell`, `task`, `view`, `web_fetch`
- `errorOccurred.errorContext` のEnum値を明記: `model_call|tool_execution|system|user_input`

### コード変更 (`src/otel_hooks/hook_event.py`)
- `MessageDisplay` → `EventType.SESSION_END` のマッピングを追加

### テスト (`tests/test_hook_payload_adapter.py`)
- `MessageDisplay` イベントのパース検証テストを追加

## 差分がなかったツール

Cursor, OpenCode, Gemini, Cline, Kiro — スペック変更なし

## Test plan

- [x] `uv run pytest tests/ -v` — 116 tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01J994o2cZxSTMRmMNkf5AWP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Hook機能の仕様書を更新し、新しいイベントタイプ（`MessageDisplay`、`PreCompact`、`PostCompact`、`SubagentStart`、`SubagentStop`）に対応
  * Hook設定方法と制約事項を明確化

* **New Features**
  * 追加のシステムイベント検知機能がHook対応に加わり、より多くのタイミングでカスタムロジックを実行可能に

* **Tests**
  * 新イベントタイプのパース処理を検証するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->