### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-06-16
+> Snapshot: 2026-06-23
 
 ## Config Location
 
@@ -61,7 +61,7 @@
 | PreToolUse | Yes (exit 2) | tool_name |
 | PermissionRequest | Yes (exit 2) | tool_name |
 | PermissionDenied | No | tool_name |
-| PostToolUse | No | tool_name |
+| PostToolUse | Yes (exit 2) | tool_name |
 | PostToolUseFailure | Yes (exit 2) | tool_name |
 | PostToolBatch | Yes (exit 2) | — |
 | Notification | No | notification_type |
@@ -71,7 +71,7 @@
 | TaskCreated | Yes (exit 2) | — |
 | TaskCompleted | Yes (exit 2) | — |
 | Stop | Yes (exit 2) | — |
-| StopFailure | No | error_type |
+| StopFailure | No | error_type: `rate_limit\|overloaded\|authentication_failed\|...` |
 | TeammateIdle | Yes (exit 2) | — |
 | ConfigChange | Yes (exit 2) | source |
 | CwdChanged | No | — |
@@ -232,7 +232,7 @@
 
 ### StopFailure
 
-- `error_type`: `rate_limit|authentication_failed|oauth_org_not_allowed|billing_error|invalid_request|model_not_found|server_error|max_output_tokens|unknown`
+- `error_type`: `rate_limit|overloaded|authentication_failed|oauth_org_not_allowed|billing_error|invalid_request|model_not_found|server_error|max_output_tokens|unknown`
 - `error_message`: string
 
 ### TeammateIdle

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-06-16
+> Snapshot: 2026-06-23
 
 ## Config Location
 
@@ -65,9 +65,9 @@ Lines with `"type": "progress"` are consumed and displayed as status; they are e
 
 ### Matcher Filtering
 
-Optional regex patterns supported for: `notification`, `permissionRequest`, `preCompact`, `preToolUse`, `subagentStart`
+Optional regex patterns supported for: `notification`, `permissionRequest`, `postToolUse`, `preCompact`, `preToolUse`, `subagentStart`
 
-## Hook Events (13 total)
+## Hook Events (14 total)
 
 | Event | Has Output | Description |
 |-------|-----------|-------------|
@@ -75,8 +75,9 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pre
 | sessionEnd | No | Session completes or terminates |
 | userPromptSubmitted | No | User submits a prompt |
 | preToolUse | Yes | Before tool execution (can deny) |
-| postToolUse | No | After tool execution |
+| postToolUse | Yes | After tool execution (can modify result) |
 | postToolUseFailure | No | After a tool completes with a failure |
+| preToolUseFailure | Yes | Tool execution error (can provide recovery guidance) |
 | errorOccurred | No | Error during execution |
 | agentStop | Yes | Main agent finishes a turn (can block) |
 | notification | No | Async system notification (CLI only) |

--- a/docs/upstream-specs/cursor.md
+++ b/docs/upstream-specs/cursor.md
@@ -1,7 +1,7 @@
 # Cursor Hooks Specification
 
 > Source: https://cursor.com/ja/docs/hooks (redirects to https://cursor.com/ja/docs/hooks)
-> Snapshot: 2026-06-16
+> Snapshot: 2026-06-23
 
 ## Config Location
 
@@ -99,6 +99,8 @@ All matching hooks from all sources execute. Conflicts resolved by priority.
   "conversation_id": "string",
   "generation_id": "string",
   "model": "string",
+  "model_id": "string (optional)",
+  "model_params": [{"id": "string", "value": "string"}],
   "hook_event_name": "string",
   "cursor_version": "string",
   "workspace_roots": ["string"],

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,7 +1,7 @@
 # Kiro Hooks Specification
 
 > Source: https://kiro.dev/docs/cli/hooks/
-> Snapshot: 2026-05-11
+> Snapshot: 2026-06-23
 
 ## Config Location
 
@@ -73,10 +73,23 @@ Additional fields:
 
 Note: `agentSpawn` hooks are never cached.
 
+## Stop Hook Output
+
+The `stop` hook can block agent termination by returning JSON on exit 0:
+
+```json
+{
+  "decision": "block",
+  "reason": "explanation becomes new user message"
+}
+```
+
+When `decision` is `"block"`, the agent continues with `reason` injected as a new user message.
+
 ## Exit Codes
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success — stdout captured (added to context for agentSpawn/userPromptSubmit) |
+| 0 | Success — stdout captured; JSON parsed for decision (agentSpawn/userPromptSubmit get stdout as context) |
 | 2 | Block execution (preToolUse only) — stderr returned to LLM |
 | Other | Warning — stderr shown to user |

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -77,6 +77,9 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "PermissionRequest": EventType.TOOL_START,
     "postToolUseFailure": EventType.TOOL_END,
     "PostToolUseFailure": EventType.TOOL_END,
+    # Copilot: fires on tool execution error before post-use (2026-06-23 spec sync)
+    "preToolUseFailure": EventType.TOOL_END,
+    "PreToolUseFailure": EventType.TOOL_END,
     "preCompact": EventType.SESSION_END,
     "PreCompact": EventType.SESSION_END,
     "subagentStart": EventType.SESSION_START,

--- a/src/otel_hooks/tools/copilot.py
+++ b/src/otel_hooks/tools/copilot.py
@@ -19,6 +19,8 @@ _HOOK_EVENTS = (
     # Added in 2026-05-18 spec sync
     "agentStop", "notification", "permissionRequest", "postToolUseFailure",
     "preCompact", "subagentStart", "subagentStop",
+    # Added in 2026-06-23 spec sync
+    "preToolUseFailure",
 )
 _EVENT_ALIASES = {
     "sessionStart": "session_start",
@@ -42,6 +44,8 @@ _EVENT_ALIASES = {
     "PermissionRequest": "permission_request",
     "postToolUseFailure": "post_tool_use_failure",
     "PostToolUseFailure": "post_tool_use_failure",
+    "preToolUseFailure": "pre_tool_use_failure",
+    "PreToolUseFailure": "pre_tool_use_failure",
     "preCompact": "pre_compact",
     "PreCompact": "pre_compact",
     "subagentStart": "subagent_start",

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -271,6 +271,20 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "claude")
         self.assertEqual(event.type, EventType.SESSION_END)
 
+    def test_parse_hook_event_for_copilot_pre_tool_use_failure(self) -> None:
+        """preToolUseFailure maps to TOOL_END (new Copilot event, 2026-06-23 spec)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "preToolUseFailure",
+            "sessionId": "cp-5",
+            "toolName": "bash",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.TOOL_END)
+
     def test_parse_hook_event_for_kiro_with_session_id(self) -> None:
         """Kiro payloads now include session_id in common fields (2026-05-04 spec update)."""
         payload = {

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -285,6 +285,20 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "copilot")
         self.assertEqual(event.type, EventType.TOOL_END)
 
+    def test_parse_hook_event_for_copilot_pre_tool_use_failure_pascal_case(self) -> None:
+        """PreToolUseFailure (PascalCase alias) also maps to TOOL_END."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "PreToolUseFailure",
+            "sessionId": "cp-5b",
+            "toolName": "bash",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.TOOL_END)
+
     def test_parse_hook_event_for_kiro_with_session_id(self) -> None:
         """Kiro payloads now include session_id in common fields (2026-05-04 spec update)."""
         payload = {

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -26,6 +26,7 @@ class MetricsHookRegistrationTest(unittest.TestCase):
             "sessionEnd", "errorOccurred",
             "agentStop", "notification", "permissionRequest", "postToolUseFailure",
             "preCompact", "subagentStart", "subagentStop",
+            "preToolUseFailure",
         ):
             self.assertIn(event_name, hooks)
             self.assertTrue(
@@ -60,6 +61,7 @@ class MetricsHookRegistrationTest(unittest.TestCase):
                 "preCompact": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStart": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStop": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "preToolUseFailure": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
             },
         }
 


### PR DESCRIPTION
## Summary

Compared `docs/upstream-specs/` snapshots against live upstream documentation (fetched 2026-06-23). Diffs detected in 4 tools:

### Copilot (`docs.github.com/en/copilot/reference/hooks-configuration`)
- **New event `preToolUseFailure`** (14 events total, was 13) — fires on tool execution error, can provide recovery guidance
- `postToolUse` now supports optional `matcher` regex field filtering by `toolName`

### Claude Code (`code.claude.com/docs/en/hooks`)
- **`PostToolUse` is now blockable** (changed from No → Yes/exit 2), resolving a contradiction where the output schema already documented `decision: "block"` but the table said non-blockable
- **`StopFailure` error_type** adds `overloaded` value to the enum

### Kiro (`kiro.dev/docs/cli/hooks/`)
- **`stop` hook output** now supports `{"decision": "block", "reason": "..."}` JSON to block agent termination; `reason` becomes a new user message

### Cursor (`cursor.com/ja/docs/hooks`)
- **Common input fields** add `model_id` (optional string) and `model_params` (`[{id, value}]` array)

## Changes

| File | Change |
|------|--------|
| `docs/upstream-specs/copilot.md` | Add `preToolUseFailure` event, add `postToolUse` to matcher list, update snapshot date |
| `docs/upstream-specs/claude.md` | Fix `PostToolUse` blockable column, add `overloaded` to StopFailure |
| `docs/upstream-specs/kiro.md` | Add Stop hook output section |
| `docs/upstream-specs/cursor.md` | Add `model_id`/`model_params` to common input |
| `src/otel_hooks/tools/copilot.py` | Register `preToolUseFailure` in `_HOOK_EVENTS` and `_EVENT_ALIASES` |
| `src/otel_hooks/hook_event.py` | Map `preToolUseFailure`/`PreToolUseFailure` → `TOOL_END` |
| `tests/test_hook_payload_adapter.py` | Add test for `preToolUseFailure` event mapping |
| `tests/test_tools_metrics_registration.py` | Update Copilot event list to include `preToolUseFailure` |

## Test plan

- [x] `uv run pytest tests/ -v` — 117 passed, 6 subtests passed

No changes for: Gemini, OpenCode, Cline (doc page inaccessible), Codex (spec still incomplete/TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CgtNczjBHLdfnTuHwYhfn

---
_Generated by [Claude Code](https://claude.ai/code/session_019CgtNczjBHLdfnTuHwYhfn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント（Documentation）**
  * 仕様書のスナップショット日付を更新しました（Claude/Copilot/Cursor/Kiro）。
  * Copilot の `preToolUseFailure` イベント仕様を追加しました。
  * Cursor に `model_id`（任意）と `model_params` フィールドを追加しました。
  * Kiro の `stop` フックと終了コードの挙動を追記しました。
* **テスト（Tests）**
  * `preToolUseFailure` の解釈と計測登録に関するテストを追加/更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->