### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-06-30
+> Snapshot: 2026-07-07
 
 ## Config Location
 
@@ -89,6 +89,7 @@
 ```json
 {
   "session_id": "string",
+  "prompt_id": "uuid",
   "transcript_path": "string",
   "cwd": "string",
   "permission_mode": "default|plan|acceptEdits|auto|dontAsk|bypassPermissions",
@@ -348,6 +349,7 @@
 - `$CLAUDE_CODE_REMOTE` — `"true"` in web environments
 - `$CLAUDE_EFFORT` — effort level (`low`, `medium`, `high`, `xhigh`, `max`)
 - `$CLAUDE_ENV_FILE` — env persist file (SessionStart, Setup, CwdChanged, FileChanged only)
+- `$CLAUDE_CODE_BRIDGE_SESSION_ID` — Remote Control session ID (v2.1.199+)
 
 ## Constraints
 

--- a/docs/upstream-specs/codex.md
+++ b/docs/upstream-specs/codex.md
@@ -1,7 +1,7 @@
 # Codex CLI Hooks Specification
 
 > Source: https://developers.openai.com/codex/config-reference
-> Snapshot: 2026-06-09
+> Snapshot: 2026-07-07
 
 ## Config Location
 
@@ -37,7 +37,8 @@ Hooks can be defined inline in `config.toml` or in `.codex/hooks.json` using the
       "hooks": [
         {
           "type": "command",
-          "command": "string"
+          "command": "string",
+          "commandWindows": "string (Windows-specific override; TOML alias: command_windows)"
         }
       ]
     }

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,24 +1,71 @@
 # Kiro Hooks Specification
 
-> Source: https://kiro.dev/docs/cli/hooks/
-> Snapshot: 2026-06-30
+> Source: https://kiro.dev/docs/hooks/
+> Snapshot: 2026-07-07
 
 ## Config Location
 
 | Scope | Path |
 |-------|------|
-| Global | `~/.kiro/agents/default.json` |
-| Project | `.kiro/agents/default.json` |
+| Workspace | `.kiro/hooks/` (directory; each JSON file defines a hook set) |
+| User | `~/.kiro/hooks/` (directory; each JSON file defines a hook set) |
 
-## Hook Events (5 total)
+otel-hooks writes to `otel-hooks.json` in the relevant directory.
 
-| Event | Description |
-|-------|-------------|
-| agentSpawn | Agent is activated |
-| userPromptSubmit | User submits a prompt |
-| preToolUse | Before tool execution (can block) |
-| postToolUse | After tool execution with results |
-| stop | Assistant finishes responding |
+## Config Schema
+
+```json
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "string (required)",
+      "description": "string (optional)",
+      "trigger": "string (required)",
+      "matcher": "regex string (optional)",
+      "action": {
+        "type": "command|agent",
+        "command": "string (command type)",
+        "prompt": "string (agent type)"
+      },
+      "timeout": 60,
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Hook Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | — | Identifier for telemetry/logging |
+| `description` | string | No | — | Human-readable documentation |
+| `trigger` | string | Yes | — | Event type (see below) |
+| `matcher` | regex | No | always-match | Filter by tool name or file path |
+| `action` | object | Yes | — | Execution instructions |
+| `timeout` | integer (seconds) | No | 60 | Command timeout (0 = disabled) |
+| `enabled` | boolean | No | true | Toggle hook without deletion |
+
+### Action Types
+
+- `command` — `{ "type": "command", "command": "shell command" }`
+- `agent` — `{ "type": "agent", "prompt": "agent prompt text" }` (timeout ignored)
+
+## Hook Events (10 total)
+
+| Trigger | Activation | Matcher Type | Blockable |
+|---------|------------|--------------|-----------|
+| `SessionStart` | Session begins | N/A | No |
+| `UserPromptSubmit` | User submits prompt | N/A | Yes |
+| `Stop` | Agent completes turn | N/A | No |
+| `PreToolUse` | Before tool executes | Tool name (regex) | Yes |
+| `PostToolUse` | After tool executes | Tool name (regex) | No |
+| `PreTaskExec` | Before spec task starts | N/A | Yes |
+| `PostTaskExec` | After spec task finishes | N/A | No |
+| `PostFileCreate` | File created by agent | File path (regex) | No |
+| `PostFileSave` | File saved by agent | File path (regex) | No |
+| `PostFileDelete` | File deleted by agent | File path (regex) | No |
 
 ## Common Input Fields (all events)
 
@@ -32,15 +79,15 @@
 
 ## Per-Event Additional Fields
 
-### userPromptSubmit
+### UserPromptSubmit
 
 - `prompt`: string (user's input text)
 
-### stop
+### Stop
 
 - `assistant_response`: string (the assistant's last message text)
 
-## Tool-Related Events (preToolUse, postToolUse)
+## Tool-Related Events (PreToolUse, PostToolUse)
 
 Additional fields:
 
@@ -48,7 +95,7 @@ Additional fields:
 {
   "tool_name": "string",
   "tool_input": "object",
-  "tool_response": "object (postToolUse only)"
+  "tool_response": "object (PostToolUse only)"
 }
 ```
 
@@ -67,33 +114,18 @@ Additional fields:
 | `@builtin` | Built-in tools only |
 | (no matcher) | All tools |
 
-## Configuration Options
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `command` | string | — | Shell command to execute |
-| `timeout_ms` | number | 30000 | Execution timeout |
-| `cache_ttl_seconds` | number | 0 | Cache successful results (0 = no cache) |
-
-Note: `agentSpawn` hooks are never cached.
-
-## Stop Hook Output
-
-The `stop` hook can block agent termination by returning JSON on exit 0:
-
-```json
-{
-  "decision": "block",
-  "reason": "explanation becomes new user message"
-}
-```
-
-When `decision` is `"block"`, the agent continues with `reason` injected as a new user message.
-
-## Exit Codes
+## Exit Codes (command actions only)
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success — stdout captured; JSON parsed for decision (agentSpawn/userPromptSubmit get stdout as context) |
-| 2 | Block execution (preToolUse only) — stderr returned to LLM |
-| Other | Warning — stderr shown to user |
+| 0 | Success — stdout added to context for SessionStart/UserPromptSubmit |
+| 2 | Block execution (PreToolUse, UserPromptSubmit, PreTaskExec only) — stderr returned to agent |
+| Other | Warning displayed; execution continues |
+
+## Constraints
+
+- `timeout` applies to command actions only (not agent actions)
+- `timeout: 0` disables the limit
+- Blocking supported only for: PreToolUse, UserPromptSubmit, PreTaskExec
+- `SessionStart` hooks are never cached
+- Matcher field filters by tool name (PreToolUse/PostToolUse) or file path (PostFileCreate/PostFileSave/PostFileDelete) using regex

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -99,6 +99,12 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "SubagentStart": EventType.SESSION_START,
     "subagentStop": EventType.SESSION_END,
     "SubagentStop": EventType.SESSION_END,
+    # Kiro new events (2026-07-07 spec sync — v1 hooks schema)
+    "PreTaskExec": EventType.SESSION_START,
+    "PostTaskExec": EventType.SESSION_END,
+    "PostFileCreate": EventType.FILE_WRITE,
+    "PostFileSave": EventType.FILE_WRITE,
+    "PostFileDelete": EventType.FILE_WRITE,
 }
 
 
@@ -113,8 +119,13 @@ def _detect_source(payload: dict[str, Any]) -> str:
         return "codex"
     if "hook_event_name" in payload:
         event_name = str(payload["hook_event_name"])
-        # Kiro uses camelCase userPromptSubmit; Copilot uses camelCase userPromptSubmitted
-        if event_name in ("userPromptSubmit", "stop", "agentSpawn"):
+        # Kiro-specific events (not shared with other tools)
+        _KIRO_SPECIFIC = frozenset({
+            "PreTaskExec", "PostTaskExec",
+            "PostFileCreate", "PostFileSave", "PostFileDelete",
+        })
+        # Old camelCase Kiro events kept for backwards compatibility
+        if event_name in _KIRO_SPECIFIC or event_name in ("userPromptSubmit", "stop", "agentSpawn"):
             return "kiro"
         return "copilot"
     if "sessionId" in payload or "transcriptPath" in payload:

--- a/src/otel_hooks/tools/kiro.py
+++ b/src/otel_hooks/tools/kiro.py
@@ -1,7 +1,7 @@
-"""Kiro CLI tool configuration (.kiro/agents/default.json).
+"""Kiro CLI tool configuration (.kiro/hooks/).
 
 Reference:
-  - https://kiro.dev/docs/cli/hooks/
+  - https://kiro.dev/docs/hooks/
 """
 
 from pathlib import Path
@@ -10,9 +10,20 @@ from typing import Any, Dict
 from . import Scope, register_tool
 from .json_io import load_json, save_json
 
-AGENT_FILE = "default.json"
-_HOOK_EVENTS = ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop")
-
+HOOKS_DIR = "hooks"
+HOOK_FILE = "otel-hooks.json"
+_HOOK_EVENTS = (
+    "SessionStart",
+    "UserPromptSubmit",
+    "Stop",
+    "PreToolUse",
+    "PostToolUse",
+    "PreTaskExec",
+    "PostTaskExec",
+    "PostFileCreate",
+    "PostFileSave",
+    "PostFileDelete",
+)
 
 
 @register_tool
@@ -26,8 +37,8 @@ class KiroConfig:
 
     def settings_path(self, scope: Scope) -> Path:
         if scope is Scope.GLOBAL:
-            return Path.home() / ".kiro" / "agents" / AGENT_FILE
-        return Path.cwd() / ".kiro" / "agents" / AGENT_FILE
+            return Path.home() / ".kiro" / HOOKS_DIR / HOOK_FILE
+        return Path.cwd() / ".kiro" / HOOKS_DIR / HOOK_FILE
 
     def load_settings(self, scope: Scope) -> Dict[str, Any]:
         return load_json(self.settings_path(scope))
@@ -36,33 +47,44 @@ class KiroConfig:
         save_json(self.settings_path(scope), settings)
 
     def is_hook_registered(self, settings: Dict[str, Any]) -> bool:
-        hooks = settings.get("hooks", {})
-        return all(
-            any("otel-hooks hook" in hook.get("command", "") for hook in hooks.get(event_name, []))
-            for event_name in _HOOK_EVENTS
-        )
+        hooks = settings.get("hooks", [])
+        if not isinstance(hooks, list):
+            return False
+        registered = {
+            hook.get("trigger")
+            for hook in hooks
+            if isinstance(hook, dict)
+            and "otel-hooks hook" in hook.get("action", {}).get("command", "")
+        }
+        return all(event in registered for event in _HOOK_EVENTS)
 
     def register_hook(self, settings: Dict[str, Any], command: str | None = None) -> Dict[str, Any]:
         base_cmd = command or "otel-hooks hook"
         cmd = f"{base_cmd} --tool kiro"
-        hooks = settings.setdefault("hooks", {})
-        for event_name in _HOOK_EVENTS:
-            group = hooks.setdefault(event_name, [])
-            if any("otel-hooks hook" in hook.get("command", "") for hook in group):
-                continue
-            group.append({"command": cmd})
+        settings.setdefault("version", "v1")
+        hooks = settings.setdefault("hooks", [])
+        existing = {
+            hook.get("trigger")
+            for hook in hooks
+            if isinstance(hook, dict)
+            and "otel-hooks hook" in hook.get("action", {}).get("command", "")
+        }
+        for trigger in _HOOK_EVENTS:
+            if trigger not in existing:
+                hooks.append({
+                    "name": "otel-hooks",
+                    "trigger": trigger,
+                    "action": {"type": "command", "command": cmd},
+                })
         return settings
 
     def unregister_hook(self, settings: Dict[str, Any]) -> Dict[str, Any]:
-        hooks = settings.get("hooks", {})
-        for event_name in _HOOK_EVENTS:
-            group = hooks.get(event_name, [])
-            if not group:
-                continue
-            hooks[event_name] = [
-                hook for hook in group if "otel-hooks hook" not in hook.get("command", "")
-            ]
-            if not hooks[event_name]:
-                del hooks[event_name]
+        hooks = settings.get("hooks", [])
+        settings["hooks"] = [
+            hook for hook in hooks
+            if not (
+                isinstance(hook, dict)
+                and "otel-hooks hook" in hook.get("action", {}).get("command", "")
+            )
+        ]
         return settings
-

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -374,6 +374,67 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "cline")
         self.assertEqual(event.session_id, "t99")
 
+    def test_parse_hook_event_for_kiro_pre_task_exec(self) -> None:
+        """PreTaskExec is Kiro-specific and maps to SESSION_START (2026-07-07 spec sync)."""
+        payload = {
+            "hook_event_name": "PreTaskExec",
+            "session_id": "kiro-1",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.SESSION_START)
+        self.assertEqual(event.session_id, "kiro-1")
+
+    def test_parse_hook_event_for_kiro_post_task_exec(self) -> None:
+        """PostTaskExec is Kiro-specific and maps to SESSION_END (2026-07-07 spec sync)."""
+        payload = {
+            "hook_event_name": "PostTaskExec",
+            "session_id": "kiro-2",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.SESSION_END)
+
+    def test_parse_hook_event_for_kiro_post_file_create(self) -> None:
+        """PostFileCreate is Kiro-specific and maps to FILE_WRITE (2026-07-07 spec sync)."""
+        payload = {
+            "hook_event_name": "PostFileCreate",
+            "session_id": "kiro-3",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.FILE_WRITE)
+
+    def test_parse_hook_event_for_kiro_post_file_save(self) -> None:
+        """PostFileSave is Kiro-specific and maps to FILE_WRITE (2026-07-07 spec sync)."""
+        payload = {
+            "hook_event_name": "PostFileSave",
+            "session_id": "kiro-4",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.FILE_WRITE)
+
+    def test_parse_hook_event_for_kiro_post_file_delete(self) -> None:
+        """PostFileDelete is Kiro-specific and maps to FILE_WRITE (2026-07-07 spec sync)."""
+        payload = {
+            "hook_event_name": "PostFileDelete",
+            "session_id": "kiro-5",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "kiro")
+        self.assertEqual(event.type, EventType.FILE_WRITE)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -106,38 +106,47 @@ class MetricsHookRegistrationTest(unittest.TestCase):
 
     def test_kiro_registers_all_metric_events(self) -> None:
         cfg = KiroConfig()
-        settings: dict[str, object] = {"hooks": {}}
+        settings: dict[str, object] = {}
 
         updated = cfg.register_hook(settings)
+        self.assertEqual(updated.get("version"), "v1")
         hooks = updated["hooks"]
+        self.assertIsInstance(hooks, list)
 
-        for event_name in ("agentSpawn", "userPromptSubmit", "preToolUse", "postToolUse", "stop"):
-            self.assertIn(event_name, hooks)
-            self.assertTrue(
-                any("otel-hooks hook" in item.get("command", "") for item in hooks[event_name])
-            )
+        registered_triggers = {
+            h["trigger"] for h in hooks if "otel-hooks hook" in h.get("action", {}).get("command", "")
+        }
+        for trigger in (
+            "SessionStart", "UserPromptSubmit", "Stop",
+            "PreToolUse", "PostToolUse",
+            "PreTaskExec", "PostTaskExec",
+            "PostFileCreate", "PostFileSave", "PostFileDelete",
+        ):
+            self.assertIn(trigger, registered_triggers, msg=f"trigger not registered: {trigger}")
 
         self.assertTrue(cfg.is_hook_registered(updated))
 
     def test_kiro_is_not_registered_when_only_stop_exists(self) -> None:
         cfg = KiroConfig()
-        settings = {"hooks": {"stop": [{"command": KIRO_HOOK_COMMAND}]}}
+        settings = {
+            "version": "v1",
+            "hooks": [{"name": "otel-hooks", "trigger": "Stop", "action": {"type": "command", "command": KIRO_HOOK_COMMAND}}],
+        }
         self.assertFalse(cfg.is_hook_registered(settings))
 
     def test_kiro_unregister_removes_registered_command_from_all_events(self) -> None:
         cfg = KiroConfig()
         settings = {
-            "hooks": {
-                "agentSpawn": [{"command": KIRO_HOOK_COMMAND}],
-                "userPromptSubmit": [{"command": KIRO_HOOK_COMMAND}],
-                "preToolUse": [{"command": KIRO_HOOK_COMMAND}],
-                "postToolUse": [{"command": KIRO_HOOK_COMMAND}],
-                "stop": [{"command": KIRO_HOOK_COMMAND}],
-            }
+            "version": "v1",
+            "hooks": [
+                {"name": "otel-hooks", "trigger": t, "action": {"type": "command", "command": KIRO_HOOK_COMMAND}}
+                for t in ("SessionStart", "UserPromptSubmit", "Stop", "PreToolUse", "PostToolUse",
+                          "PreTaskExec", "PostTaskExec", "PostFileCreate", "PostFileSave", "PostFileDelete")
+            ],
         }
 
         updated = cfg.unregister_hook(settings)
-        self.assertEqual(updated["hooks"], {})
+        self.assertEqual(updated["hooks"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Upstream docs comparison detected changes in 3 tools. No changes found for Cursor, OpenCode, Gemini, Cline, or Copilot (GitHub docs were unreachable due to network policy).

### Kiro — major breaking changes (config schema redesigned in v1)

- **Config location changed**: `.kiro/agents/default.json` → `.kiro/hooks/` directory (individual JSON files per hook set); otel-hooks now writes to `.kiro/hooks/otel-hooks.json`
- **Schema redesigned**: flat `hooks` dict → `{ "version": "v1", "hooks": [ {name, trigger, action, timeout, enabled} ] }` array-of-objects format
- **Events expanded**: 5 → 10 triggers
  - Renamed: `agentSpawn` → `SessionStart`
  - Added: `PreTaskExec`, `PostTaskExec`, `PostFileCreate`, `PostFileSave`, `PostFileDelete`
- **New action type**: `agent` (`{ "type": "agent", "prompt": "..." }`) alongside `command`
- **Timeout unit changed**: `timeout_ms` (ms) → `timeout` (seconds, default 60)
- **`cache_ttl_seconds` removed**; new `enabled` boolean field added

### Claude Code — minor additions

- `prompt_id: uuid` added to common input fields
- `$CLAUDE_CODE_BRIDGE_SESSION_ID` env var added (Remote Control session ID, v2.1.199+)

### Codex — minor addition

- `commandWindows` / `command_windows` field documented (Windows-specific command override for hook handlers)

## Files changed

| File | Change |
|------|--------|
| `docs/upstream-specs/kiro.md` | Complete rewrite; snapshot → 2026-07-07 |
| `docs/upstream-specs/claude.md` | Add `prompt_id`, `CLAUDE_CODE_BRIDGE_SESSION_ID`; snapshot → 2026-07-07 |
| `docs/upstream-specs/codex.md` | Add `commandWindows`; snapshot → 2026-07-07 |
| `src/otel_hooks/tools/kiro.py` | New schema for `is_hook_registered`, `register_hook`, `unregister_hook`; updated `settings_path` |
| `src/otel_hooks/hook_event.py` | Map new Kiro events (`PreTaskExec`→`SESSION_START`, `PostTaskExec`→`SESSION_END`, `PostFileCreate/Save/Delete`→`FILE_WRITE`); update source detection |
| `tests/test_tools_metrics_registration.py` | Update Kiro tests for new array schema and 10 triggers |
| `tests/test_hook_payload_adapter.py` | Add 5 new tests for Kiro-specific events |

All 128 tests pass (`uv run pytest tests/ -v`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVLtNvBnajF4AZgYAUgFvV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiro の新しいフックイベントや設定形式に対応し、より多くの操作を監視・連携できるようになりました。
  * Kiro のフック設定の登録・解除が新しい構成に合わせて更新されました。
* **Documentation**
  * Claude、Codex、Kiro の仕様ドキュメントを最新内容に更新しました。
  * 新しい入力フィールド、環境変数、イベント一覧、設定項目の説明を反映しました。
* **Tests**
  * Kiro の新イベントや設定形式に対応するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->