### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-06-23
+> Snapshot: 2026-07-14
 
 ## Config Location
 
@@ -67,7 +67,7 @@ Lines with `"type": "progress"` are consumed and displayed as status; they are e
 
 Optional regex patterns supported for: `notification`, `permissionRequest`, `postToolUse`, `preCompact`, `preToolUse`, `subagentStart`
 
-## Hook Events (14 total)
+## Hook Events (13 total)
 
 | Event | Has Output | Description |
 |-------|-----------|-------------|
@@ -77,13 +77,12 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pos
 | preToolUse | Yes | Before tool execution (can deny) |
 | postToolUse | Yes | After tool execution (can modify result) |
 | postToolUseFailure | No | After a tool completes with a failure |
-| preToolUseFailure | Yes | Tool execution error (can provide recovery guidance) |
 | errorOccurred | No | Error during execution |
 | agentStop | Yes | Main agent finishes a turn (can block) |
 | notification | No | Async system notification (CLI only) |
 | permissionRequest | Yes | Before permission service runs (CLI only) |
 | preCompact | No | Context compaction is about to begin |
-| subagentStart | No | A subagent is spawned (before it runs) |
+| subagentStart | Yes | A subagent is spawned; can inject context (cannot block) |
 | subagentStop | Yes | A subagent completes (can block) |
 
 ## Per-Event Input Schemas
@@ -270,6 +269,14 @@ Note: only `deny` is processed.
     "textResultForLlm": "string"
   },
   "additionalContext": "string (optional)"
+}
+```
+
+### subagentStart
+
+```json
+{
+  "additionalContext": "string (optional, prepended to subagent prompt; cannot block)"
 }
 ```
 

--- a/docs/upstream-specs/cursor.md
+++ b/docs/upstream-specs/cursor.md
@@ -1,7 +1,7 @@
 # Cursor Hooks Specification
 
 > Source: https://cursor.com/ja/docs/hooks (redirects to https://cursor.com/ja/docs/hooks)
-> Snapshot: 2026-06-23
+> Snapshot: 2026-07-14
 
 ## Config Location
 
@@ -488,9 +488,9 @@ All matching hooks from all sources execute. Conflicts resolved by priority.
 
 Cloud agents execute command-based hooks from `.cursor/hooks.json` only. User-level hooks are unavailable to cloud agents.
 
-**Supported in cloud agents**: `beforeShellExecution`, `afterShellExecution`, `beforeReadFile`, `afterFileEdit`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `preCompact`
+**Supported in cloud agents**: `beforeShellExecution`, `afterShellExecution`, `beforeReadFile`, `afterFileEdit`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `beforeSubmitPrompt`, `preCompact`, `afterAgentResponse`, `afterAgentThought`, `stop`
 
-**Not supported in cloud agents**: `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `beforeTabFileRead`, `afterTabFileEdit`, `workspaceOpen`, `beforeMCPExecution`, `afterMCPExecution`, `afterAgentResponse`, `afterAgentThought`, `stop`
+**Not supported in cloud agents**: `sessionStart`, `sessionEnd`, `beforeTabFileRead`, `afterTabFileEdit`, `workspaceOpen`, `beforeMCPExecution`, `afterMCPExecution`
 
 Team/enterprise hooks are also unavailable in cloud agents.
 

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -77,7 +77,7 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "PermissionRequest": EventType.TOOL_START,
     "postToolUseFailure": EventType.TOOL_END,
     "PostToolUseFailure": EventType.TOOL_END,
-    # Copilot: fires on tool execution error before post-use (2026-06-23 spec sync)
+    # preToolUseFailure: removed from Copilot spec (2026-07-14); kept for backward compat
     "preToolUseFailure": EventType.TOOL_END,
     "PreToolUseFailure": EventType.TOOL_END,
     # Cline SDK hooks (2026-06-30 spec sync — new SDK-based event model)

--- a/src/otel_hooks/tools/copilot.py
+++ b/src/otel_hooks/tools/copilot.py
@@ -19,8 +19,6 @@ _HOOK_EVENTS = (
     # Added in 2026-05-18 spec sync
     "agentStop", "notification", "permissionRequest", "postToolUseFailure",
     "preCompact", "subagentStart", "subagentStop",
-    # Added in 2026-06-23 spec sync
-    "preToolUseFailure",
 )
 _EVENT_ALIASES = {
     "sessionStart": "session_start",
@@ -44,8 +42,6 @@ _EVENT_ALIASES = {
     "PermissionRequest": "permission_request",
     "postToolUseFailure": "post_tool_use_failure",
     "PostToolUseFailure": "post_tool_use_failure",
-    "preToolUseFailure": "pre_tool_use_failure",
-    "PreToolUseFailure": "pre_tool_use_failure",
     "preCompact": "pre_compact",
     "PreCompact": "pre_compact",
     "subagentStart": "subagent_start",

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -272,7 +272,7 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.type, EventType.SESSION_END)
 
     def test_parse_hook_event_for_copilot_pre_tool_use_failure(self) -> None:
-        """preToolUseFailure maps to TOOL_END (new Copilot event, 2026-06-23 spec)."""
+        """preToolUseFailure removed from Copilot spec (2026-07-14); backward-compat mapping retained."""
         payload = {
             "source_tool": "copilot",
             "hook_event_name": "preToolUseFailure",
@@ -286,7 +286,7 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.type, EventType.TOOL_END)
 
     def test_parse_hook_event_for_copilot_pre_tool_use_failure_pascal_case(self) -> None:
-        """PreToolUseFailure (PascalCase alias) also maps to TOOL_END."""
+        """PreToolUseFailure (PascalCase alias) also maps to TOOL_END (backward compat)."""
         payload = {
             "source_tool": "copilot",
             "hook_event_name": "PreToolUseFailure",

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -26,7 +26,6 @@ class MetricsHookRegistrationTest(unittest.TestCase):
             "sessionEnd", "errorOccurred",
             "agentStop", "notification", "permissionRequest", "postToolUseFailure",
             "preCompact", "subagentStart", "subagentStop",
-            "preToolUseFailure",
         ):
             self.assertIn(event_name, hooks)
             self.assertTrue(
@@ -61,7 +60,6 @@ class MetricsHookRegistrationTest(unittest.TestCase):
                 "preCompact": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStart": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStop": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
-                "preToolUseFailure": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
             },
         }
 


### PR DESCRIPTION
## Summary

Upstream spec comparison against `docs/upstream-specs/` revealed two diffs (2026-07-14 snapshot):

### Copilot — 2 changes
- **`preToolUseFailure` removed** from the upstream spec (14 → 13 events). Registration in `copilot.py` and related tests updated. The event mapping in `hook_event.py` is retained for backward compatibility so existing configs that still fire this event continue to be handled gracefully.
- **`subagentStart` now has output** — upstream added `additionalContext?: string` (prepended to subagent prompt; cannot block). Spec snapshot and event table updated accordingly.

### Cursor — 1 change
- **Cloud agent supported hook set expanded.** `beforeSubmitPrompt`, `afterAgentResponse`, `afterAgentThought`, and `stop` are now listed as supported in cloud agents (previously marked unsupported). Spec snapshot updated; no code change needed since these events are not part of the hooks otel-hooks registers.

### No changes detected
Claude Code, Gemini, Cline, Kiro, OpenCode, Codex — all match their current snapshots.

## Test plan

- [x] `uv run pytest tests/ -v` — 128 passed, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3q8Pcs4m9hTKjU1dKePsV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * CopilotおよびCursorのフック仕様を最新内容に更新しました。
  * Copilotのイベント一覧と、サブエージェント開始時に利用できる追加コンテキストの説明を更新しました。
  * Cursorのクラウドエージェント対応イベントを整理しました。

* **変更**
  * Copilotの`preToolUseFailure`イベントを新規登録対象から削除しました。
  * 既存データとの互換性のため、同イベントの変換処理は引き続き維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->