### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-07-07
+> Snapshot: 2026-07-21
 
 ## Config Location
 
@@ -248,8 +248,7 @@
 
 ### Stop
 
-- `response`: string (Claude's full response text; formerly `assistant_message`)
-- `stop_reason`: string (e.g. `end_turn`)
+- `last_assistant_message`: string (Claude's full response text; formerly `response`, before that `assistant_message`)
 
 ### SessionEnd
 
@@ -305,10 +304,17 @@
 - `hookSpecificOutput.updatedToolOutput`: string (optional, replaces tool output seen by Claude)
 - `hookSpecificOutput.additionalContext`: string (optional, appended context for Claude)
 
-### PostToolBatch / Stop / TaskCreated / TaskCompleted / PreCompact
+### PostToolBatch / TaskCreated / TaskCompleted / PreCompact
 
 - `decision`: `"block"` (optional)
 - `reason`: string
+
+### Stop (output)
+
+- `decision`: `"block"` (optional)
+- `reason`: string
+- `hookSpecificOutput.hookEventName`: `"Stop"`
+- `hookSpecificOutput.additionalContext`: string (non-error feedback injected into next turn)
 
 ### PermissionRequest
 

--- a/docs/upstream-specs/codex.md
+++ b/docs/upstream-specs/codex.md
@@ -1,7 +1,8 @@
 # Codex CLI Hooks Specification
 
-> Source: https://developers.openai.com/codex/config-reference
-> Snapshot: 2026-07-07
+> Source: https://learn.chatgpt.com/docs/config-file/config-reference
+> (Formerly https://developers.openai.com/codex/config-reference — 308 permanent redirect as of 2026-07-21)
+> Snapshot: 2026-07-21
 
 ## Config Location
 

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-07-14
+> Snapshot: 2026-07-21
 
 ## Config Location
 
@@ -67,13 +67,14 @@ Lines with `"type": "progress"` are consumed and displayed as status; they are e
 
 Optional regex patterns supported for: `notification`, `permissionRequest`, `postToolUse`, `preCompact`, `preToolUse`, `subagentStart`
 
-## Hook Events (13 total)
+## Hook Events (14 total)
 
 | Event | Has Output | Description |
 |-------|-----------|-------------|
 | sessionStart | No | New or resumed session begins |
 | sessionEnd | No | Session completes or terminates |
 | userPromptSubmitted | No | User submits a prompt |
+| userPromptTransformed | Yes | After prompt transformation, before model receives it |
 | preToolUse | Yes | Before tool execution (can deny) |
 | postToolUse | Yes | After tool execution (can modify result) |
 | postToolUseFailure | No | After a tool completes with a failure |
@@ -118,6 +119,25 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pos
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "prompt": "string"
+}
+```
+
+### userPromptTransformed
+
+```json
+{
+  "sessionId": "string",
+  "timestamp": "number (Unix ms)",
+  "cwd": "string",
+  "prompt": "string",
+  "transformedPrompt": "string"
+}
+```
+
+Output:
+```json
+{
+  "modifiedTransformedPrompt": "string"
 }
 ```
 

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -80,6 +80,9 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     # preToolUseFailure: removed from Copilot spec (2026-07-14); kept for backward compat
     "preToolUseFailure": EventType.TOOL_END,
     "PreToolUseFailure": EventType.TOOL_END,
+    # Copilot new events (2026-07-21 spec sync)
+    "userPromptTransformed": EventType.PROMPT_SUBMIT,
+    "UserPromptTransformed": EventType.PROMPT_SUBMIT,
     # Cline SDK hooks (2026-06-30 spec sync — new SDK-based event model)
     "session_start": EventType.SESSION_START,
     "run_start": EventType.SESSION_START,

--- a/src/otel_hooks/tools/copilot.py
+++ b/src/otel_hooks/tools/copilot.py
@@ -19,6 +19,8 @@ _HOOK_EVENTS = (
     # Added in 2026-05-18 spec sync
     "agentStop", "notification", "permissionRequest", "postToolUseFailure",
     "preCompact", "subagentStart", "subagentStop",
+    # Added in 2026-07-21 spec sync
+    "userPromptTransformed",
 )
 _EVENT_ALIASES = {
     "sessionStart": "session_start",
@@ -48,6 +50,9 @@ _EVENT_ALIASES = {
     "SubagentStart": "subagent_start",
     "subagentStop": "subagent_stop",
     "SubagentStop": "subagent_stop",
+    # Added in 2026-07-21 spec sync
+    "userPromptTransformed": "user_prompt_transformed",
+    "UserPromptTransformed": "user_prompt_transformed",
 }
 
 

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -435,6 +435,35 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "kiro")
         self.assertEqual(event.type, EventType.FILE_WRITE)
 
+    def test_parse_hook_event_for_copilot_user_prompt_transformed(self) -> None:
+        """userPromptTransformed maps to PROMPT_SUBMIT (new Copilot event, 2026-07-21 spec sync)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "userPromptTransformed",
+            "sessionId": "cp-6",
+            "cwd": "/tmp",
+            "prompt": "original user prompt",
+            "transformedPrompt": "system-transformed prompt sent to model",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
+        self.assertEqual(event.session_id, "cp-6")
+
+    def test_parse_hook_event_for_copilot_user_prompt_transformed_pascal_case(self) -> None:
+        """UserPromptTransformed (PascalCase alias) also maps to PROMPT_SUBMIT."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "UserPromptTransformed",
+            "sessionId": "cp-7",
+            "cwd": "/tmp",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -26,6 +26,8 @@ class MetricsHookRegistrationTest(unittest.TestCase):
             "sessionEnd", "errorOccurred",
             "agentStop", "notification", "permissionRequest", "postToolUseFailure",
             "preCompact", "subagentStart", "subagentStop",
+            # Added in 2026-07-21 spec sync
+            "userPromptTransformed",
         ):
             self.assertIn(event_name, hooks)
             self.assertTrue(
@@ -60,6 +62,7 @@ class MetricsHookRegistrationTest(unittest.TestCase):
                 "preCompact": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStart": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
                 "subagentStop": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
+                "userPromptTransformed": [{"type": "command", "bash": COPILOT_HOOK_COMMAND}],
             },
         }
 


### PR DESCRIPTION
## Summary

Automated upstream spec comparison run (2026-07-21) detected three changes across tool documentation and applied corresponding implementation updates.

## Detected Diffs

### GitHub Copilot — new `userPromptTransformed` event (13 → 14 events)

The official docs at https://docs.github.com/en/copilot/reference/hooks-configuration now list a 14th hook event:

| Field | Value |
|-------|-------|
| Event name | `userPromptTransformed` |
| Fires | After prompt transformation, before the model receives it |
| Input | `prompt` (original), `transformedPrompt` (runtime-modified) |
| Output | `modifiedTransformedPrompt: string` |
| Surfaces | CLI + cloud agent |

Implementation changes:
- Added `"userPromptTransformed"` to `_HOOK_EVENTS` in `tools/copilot.py`
- Added camelCase + PascalCase aliases to `_EVENT_ALIASES`
- Mapped to `EventType.PROMPT_SUBMIT` in `hook_event.py`

### Claude Code — `Stop` event field rename

The `Stop` event input field was renamed:

```
response  →  last_assistant_message
```
(previously renamed from `assistant_message` → `response`; this is the second rename)

The `Stop` event output now has a dedicated `hookSpecificOutput` structure:
```json
{
  "hookSpecificOutput": {
    "hookEventName": "Stop",
    "additionalContext": "string"
  }
}
```

Documentation-only change; no implementation impact (the hook reads transcript, not Stop payload fields).

### Codex — source URL permanently redirected

`https://developers.openai.com/codex/config-reference` now issues a 308 permanent redirect to:
`https://learn.chatgpt.com/docs/config-file/config-reference`

Content (10 events, same schema) is unchanged. Updated snapshot source URL.

## Files Changed

| File | Change |
|------|--------|
| `docs/upstream-specs/copilot.md` | Add `userPromptTransformed` event + schema; bump snapshot date |
| `docs/upstream-specs/claude.md` | Update Stop field name + output schema; bump snapshot date |
| `docs/upstream-specs/codex.md` | Update source URL; bump snapshot date |
| `src/otel_hooks/tools/copilot.py` | Add `userPromptTransformed` to `_HOOK_EVENTS` and `_EVENT_ALIASES` |
| `src/otel_hooks/hook_event.py` | Map `userPromptTransformed`/`UserPromptTransformed` → `PROMPT_SUBMIT` |
| `tests/test_hook_payload_adapter.py` | Add two tests for the new Copilot event |
| `tests/test_tools_metrics_registration.py` | Include `userPromptTransformed` in registration assertions |

## Test Results

130 passed, 6 subtests passed (was 128 before; +2 new tests for the new event).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZ62VVeLVVBviQ3GWm1pzT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - GitHub Copilotの`userPromptTransformed`フックイベントに対応しました。
  - 変換前後のプロンプト情報を受け取り、プロンプト送信イベントとして処理できます。
  - フックの登録・解除および設定状態の確認対象に追加しました。

- **仕様更新**
  - Claude、Codex、Copilotの最新フック仕様とスナップショット情報を反映しました。

- **バグ修正**
  - 新しいCopilotイベントが誤ったイベント種別として処理される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->