### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-07-21
+> Snapshot: 2026-07-28
 
 ## Config Location
 
@@ -53,7 +53,7 @@
 
 | Event | Blockable | Matcher Target |
 |-------|-----------|----------------|
-| SessionStart | No | source: `startup\|resume\|clear\|compact` |
+| SessionStart | No | source: `startup\|resume\|clear\|compact\|fork` |
 | Setup | No | trigger: `init\|maintenance` |
 | InstructionsLoaded | No | load_reason: `session_start\|nested_traversal\|path_glob_match\|include\|compact` |
 | UserPromptSubmit | Yes (exit 2) | — |
@@ -106,7 +106,7 @@
 
 ### SessionStart
 
-- `source`: `startup|resume|clear|compact`
+- `source`: `startup|resume|clear|compact|fork`
 - `model`: string
 - `agent_type`: string (optional)
 - `session_title`: string (optional)

--- a/docs/upstream-specs/kiro.md
+++ b/docs/upstream-specs/kiro.md
@@ -1,7 +1,7 @@
 # Kiro Hooks Specification
 
-> Source: https://kiro.dev/docs/hooks/
-> Snapshot: 2026-07-07
+> Source: https://kiro.dev/docs/cli/hooks/
+> Snapshot: 2026-07-28
 
 ## Config Location
 
@@ -45,6 +45,8 @@ otel-hooks writes to `otel-hooks.json` in the relevant directory.
 | `matcher` | regex | No | always-match | Filter by tool name or file path |
 | `action` | object | Yes | — | Execution instructions |
 | `timeout` | integer (seconds) | No | 60 | Command timeout (0 = disabled) |
+| `timeout_ms` | integer (ms) | No | 30000 | Hook execution timeout (alternative to `timeout`; added 2026-07-28) |
+| `cache_ttl_seconds` | integer | No | 0 | Cache successful hook results; 0 = no caching (added 2026-07-28) |
 | `enabled` | boolean | No | true | Toggle hook without deletion |
 
 ### Action Types
@@ -52,13 +54,14 @@ otel-hooks writes to `otel-hooks.json` in the relevant directory.
 - `command` — `{ "type": "command", "command": "shell command" }`
 - `agent` — `{ "type": "agent", "prompt": "agent prompt text" }` (timeout ignored)
 
-## Hook Events (10 total)
+## Hook Events (11 total)
 
 | Trigger | Activation | Matcher Type | Blockable |
 |---------|------------|--------------|-----------|
+| `AgentSpawn` | Agent activates (added 2026-07-28) | N/A | No |
 | `SessionStart` | Session begins | N/A | No |
 | `UserPromptSubmit` | User submits prompt | N/A | Yes |
-| `Stop` | Agent completes turn | N/A | No |
+| `Stop` | Agent completes turn | N/A | Yes (block decision via `{"decision": "block", "reason": "..."}`) |
 | `PreToolUse` | Before tool executes | Tool name (regex) | Yes |
 | `PostToolUse` | After tool executes | Tool name (regex) | No |
 | `PreTaskExec` | Before spec task starts | N/A | Yes |
@@ -126,6 +129,6 @@ Additional fields:
 
 - `timeout` applies to command actions only (not agent actions)
 - `timeout: 0` disables the limit
-- Blocking supported only for: PreToolUse, UserPromptSubmit, PreTaskExec
+- Blocking supported for: PreToolUse, UserPromptSubmit, PreTaskExec, Stop (via JSON `{"decision": "block", "reason": "..."}` output)
 - `SessionStart` hooks are never cached
 - Matcher field filters by tool name (PreToolUse/PostToolUse) or file path (PostFileCreate/PostFileSave/PostFileDelete) using regex

--- a/src/otel_hooks/tools/kiro.py
+++ b/src/otel_hooks/tools/kiro.py
@@ -1,7 +1,7 @@
 """Kiro CLI tool configuration (.kiro/hooks/).
 
 Reference:
-  - https://kiro.dev/docs/hooks/
+  - https://kiro.dev/docs/cli/hooks/
 """
 
 from pathlib import Path
@@ -13,6 +13,7 @@ from .json_io import load_json, save_json
 HOOKS_DIR = "hooks"
 HOOK_FILE = "otel-hooks.json"
 _HOOK_EVENTS = (
+    "AgentSpawn",
     "SessionStart",
     "UserPromptSubmit",
     "Stop",

--- a/tests/test_tools_metrics_registration.py
+++ b/tests/test_tools_metrics_registration.py
@@ -118,7 +118,7 @@ class MetricsHookRegistrationTest(unittest.TestCase):
             h["trigger"] for h in hooks if "otel-hooks hook" in h.get("action", {}).get("command", "")
         }
         for trigger in (
-            "SessionStart", "UserPromptSubmit", "Stop",
+            "AgentSpawn", "SessionStart", "UserPromptSubmit", "Stop",
             "PreToolUse", "PostToolUse",
             "PreTaskExec", "PostTaskExec",
             "PostFileCreate", "PostFileSave", "PostFileDelete",
@@ -141,7 +141,7 @@ class MetricsHookRegistrationTest(unittest.TestCase):
             "version": "v1",
             "hooks": [
                 {"name": "otel-hooks", "trigger": t, "action": {"type": "command", "command": KIRO_HOOK_COMMAND}}
-                for t in ("SessionStart", "UserPromptSubmit", "Stop", "PreToolUse", "PostToolUse",
+                for t in ("AgentSpawn", "SessionStart", "UserPromptSubmit", "Stop", "PreToolUse", "PostToolUse",
                           "PreTaskExec", "PostTaskExec", "PostFileCreate", "PostFileSave", "PostFileDelete")
             ],
         }


### PR DESCRIPTION
## Summary

Compared `docs/upstream-specs/` snapshots against live official documentation (fetched 2026-07-28). Two tools had upstream changes.

### Claude Code (`docs/upstream-specs/claude.md`)

- **SessionStart `fork` source added** — The official docs now list `fork` as a valid `source` value alongside `startup|resume|clear|compact`. This occurs when a session is forked from another (e.g. via the Agent tool with `isolation: "worktree"`). Updated both the events table and the per-event input fields section.

### Kiro (`docs/upstream-specs/kiro.md`, `src/otel_hooks/tools/kiro.py`)

- **URL changed** — Official docs moved from `https://kiro.dev/docs/hooks/` to `https://kiro.dev/docs/cli/hooks/`
- **New event: `AgentSpawn`** — Triggered when the agent activates; added to the spec and registered in `_HOOK_EVENTS` so otel-hooks emits it
- **New config fields** — `timeout_ms` (integer milliseconds, default 30000) and `cache_ttl_seconds` (cache duration for hook results, default 0 = disabled) documented in the schema table
- **`Stop` is now blockable** — The official docs describe a block-decision mechanism (`{"decision": "block", "reason": "..."}`) for the Stop hook; updated blockable column and constraints note

## No changes detected

Cursor, Gemini, Cline, Copilot, Codex, OpenCode — specs are current.

## Test plan

- [x] `uv run pytest tests/ -v` — 130 passed, 0 failures
- [x] `test_kiro_registers_all_metric_events` now asserts `AgentSpawn` is registered
- [x] `test_kiro_unregister_removes_registered_command_from_all_events` covers `AgentSpawn`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpCAerk6GkKdiBKfUS8uEx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Kiro Hooksで`AgentSpawn`イベントに対応しました。
  * Kiro Hooksのブロック対象イベントに`Stop`を追加しました。
  * フック設定でタイムアウトとキャッシュ保持時間を指定できるようになりました。
  * Claudeのセッション開始ソースに`fork`を追加しました。

* **ドキュメント**
  * ClaudeおよびKiro Hooksの仕様情報を最新版に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->