### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-07-28
+> Snapshot: 2026-08-04
 
 ## Config Location
 
@@ -49,7 +49,7 @@
 - `prompt` — LLM prompt (`prompt`, `model`)
 - `agent` — agent invocation (`prompt`, `model`) [experimental]
 
-## Hook Events (30 total)
+## Hook Events (31 total)
 
 | Event | Blockable | Matcher Target |
 |-------|-----------|----------------|
@@ -75,6 +75,7 @@
 | TeammateIdle | Yes (exit 2) | — |
 | ConfigChange | Yes (exit 2) | source |
 | CwdChanged | No | — |
+| DirectoryAdded | No | — |
 | FileChanged | No | filename (basename) |
 | WorktreeCreate | Yes (exit 2) | — |
 | WorktreeRemove | No | — |
@@ -188,6 +189,10 @@
 
 - `old_cwd`: string
 - `new_cwd`: string
+
+### DirectoryAdded
+
+- `directory_path`: string (absolute path of newly added directory)
 
 ### FileChanged
 
@@ -359,7 +364,8 @@
 
 ## Constraints
 
-- Hook output capped at 10,000 characters
+- Hook output capped at 10,000 characters (exceeding saves to file with shortened model preview)
 - All matching hooks run in parallel
 - Identical handlers deduplicated by command/URL
 - JSON-only stdout on exit 0
+- `OTEL_*` exporter variables are removed from all subprocess environments

--- a/docs/upstream-specs/codex.md
+++ b/docs/upstream-specs/codex.md
@@ -2,7 +2,7 @@
 
 > Source: https://learn.chatgpt.com/docs/config-file/config-reference
 > (Formerly https://developers.openai.com/codex/config-reference — 308 permanent redirect as of 2026-07-21)
-> Snapshot: 2026-07-21
+> Snapshot: 2026-08-04
 
 ## Config Location
 
@@ -49,11 +49,16 @@ Hooks can be defined inline in `config.toml` or in `.codex/hooks.json` using the
 
 Note: Only `command` hook handlers are currently executed; `prompt` and `agent` types are parsed but skipped.
 
-## Documented Hook Events (10)
+### Output Management
+
+The `additionalContextLimit` parameter (default: 2500 tokens) controls when oversized hook output is saved to disk with a shortened model preview. Setting to `0` passes full output directly to the model.
+
+## Documented Hook Events (11)
 
 | Event | Description |
 |-------|-------------|
 | `SessionStart` | Session begins |
+| `SessionEnd` | Session terminates (added 2026-08-04) |
 | `UserPromptSubmit` | User submits a prompt |
 | `PreToolUse` | Before tool execution |
 | `PermissionRequest` | Permission dialog appears |

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-07-21
+> Snapshot: 2026-08-04
 
 ## Config Location
 
@@ -207,7 +207,8 @@ Output:
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "transcriptPath": "string",
-  "stopReason": "string"
+  "stopReason": "string",
+  "stop_hook_active": "boolean (true when a previous Stop hook blocked)"
 }
 ```
 
@@ -233,8 +234,11 @@ Output:
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "transcriptPath": "string",
+  "agentId": "string",
+  "agentType": "string",
   "agentName": "string",
   "agentDisplayName": "string (optional)",
+  "response": "string (subagent's final response text)",
   "stopReason": "string"
 }
 ```
@@ -300,12 +304,22 @@ Note: only `deny` is processed.
 }
 ```
 
-### agentStop / subagentStop
+### agentStop
 
 ```json
 {
   "decision": "block|allow",
   "reason": "string"
+}
+```
+
+### subagentStop
+
+```json
+{
+  "decision": "block|allow",
+  "reason": "string",
+  "modifiedResponse": "string (optional, replaces subagent response returned to parent)"
 }
 ```
 

--- a/src/otel_hooks/hook_event.py
+++ b/src/otel_hooks/hook_event.py
@@ -68,6 +68,8 @@ _METRIC_EVENT_MAP: dict[str, EventType] = {
     "AgentSpawn": EventType.SESSION_START,
     # Claude Code new events (2026-06-09 spec sync)
     "MessageDisplay": EventType.SESSION_END,
+    # Claude Code new events (2026-08-04 spec sync)
+    "DirectoryAdded": EventType.SESSION_END,
     # Copilot new events (2026-05-18 spec sync)
     "agentStop": EventType.SESSION_END,
     "AgentStop": EventType.SESSION_END,

--- a/tests/test_hook_payload_adapter.py
+++ b/tests/test_hook_payload_adapter.py
@@ -464,6 +464,38 @@ class HookPayloadAdapterTest(unittest.TestCase):
         self.assertEqual(event.source, "copilot")
         self.assertEqual(event.type, EventType.PROMPT_SUBMIT)
 
+    def test_parse_hook_event_for_claude_directory_added(self) -> None:
+        """DirectoryAdded maps to SESSION_END (new Claude Code event, 2026-08-04 spec sync)."""
+        payload = {
+            "source_tool": "claude",
+            "hook_event_name": "DirectoryAdded",
+            "session_id": "s1",
+            "directory_path": "/home/user/new-dir",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "claude")
+        self.assertEqual(event.type, EventType.SESSION_END)
+
+    def test_parse_hook_event_for_copilot_subagent_stop_with_new_fields(self) -> None:
+        """subagentStop payload now includes agentId, agentType, response (2026-08-04 spec sync)."""
+        payload = {
+            "source_tool": "copilot",
+            "hook_event_name": "subagentStop",
+            "sessionId": "cp-8",
+            "cwd": "/tmp",
+            "agentId": "agent-123",
+            "agentType": "general-purpose",
+            "agentName": "my-agent",
+            "response": "I completed the task.",
+            "stopReason": "end_turn",
+        }
+        event = parse_hook_event(payload)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.source, "copilot")
+        self.assertEqual(event.type, EventType.SESSION_END)
+        self.assertEqual(event.session_id, "cp-8")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Synced upstream official documentation for 3 tools where differences were detected (2026-08-04 snapshot).

### Claude Code — new `DirectoryAdded` event (31 total, was 30)
- Fires when a directory is added to the monitored workspace mid-session
- Cannot block; categorized alongside `CwdChanged` / `FileChanged` as an async/side-effect event
- Added note: `OTEL_*` exporter variables are removed from all subprocess environments
- `hook_event.py`: mapped `DirectoryAdded` → `EventType.SESSION_END`

### GitHub Copilot — schema changes in `subagentStop` and `agentStop`
- `subagentStop` input: new `agentId`, `agentType`, `response` fields
- `subagentStop` output: new `modifiedResponse?` field (allows redacting/reformatting subagent response before it reaches the parent)
- `agentStop` input: new `stop_hook_active` boolean (true when a prior Stop hook already blocked)

### Codex — `SessionEnd` event added + `additionalContextLimit` parameter
- `SessionEnd` is now documented (11 events total, was 10)
- New `additionalContextLimit` config parameter (default: 2500 tokens) controls when oversized hook output is saved to disk

### No changes detected
Cursor (count mismatch in upstream doc appears to be a documentation error — events are unchanged), Gemini, Cline, OpenCode, Kiro snapshots are up to date.

## Test plan

- [x] `uv run pytest tests/ -v` — 132 passed, 0 failures
- [x] New test: `test_parse_hook_event_for_claude_directory_added` — `DirectoryAdded` maps to `SESSION_END`
- [x] New test: `test_parse_hook_event_for_copilot_subagent_stop_with_new_fields` — `subagentStop` with `agentId`/`agentType`/`response` fields parses correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU223W2knFdGSS9pd26zFK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Claude Codeの`DirectoryAdded`およびCopilotの`subagentStop`イベントに対応しました。
  * 新しいエージェント情報、停止理由、変更後レスポンスを扱えるようになりました。
  * フック出力の切り詰め・保存に関する仕様を追加し、完全出力にも対応しました。

* **ドキュメント**
  * Claude Code、Codex、Copilotの最新フック仕様を反映しました。
  * イベント数、入力項目、出力形式、制約事項を更新しました。

* **テスト**
  * 新しいイベントの変換とセッション情報の処理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->