### PR TITLE
chore: sync upstream tool specs

### DIFF
--- a/docs/upstream-specs/claude.md
+++ b/docs/upstream-specs/claude.md
@@ -1,7 +1,7 @@
 # Claude Code Hooks Specification
 
 > Source: https://code.claude.com/docs/en/hooks
-> Snapshot: 2026-08-04
+> Snapshot: 2026-08-11
 
 ## Config Location
 
@@ -64,7 +64,7 @@
 | PostToolUse | Yes (exit 2) | tool_name |
 | PostToolUseFailure | Yes (exit 2) | tool_name |
 | PostToolBatch | Yes (exit 2) | — |
-| Notification | No | notification_type |
+| Notification | No | notification_type: `permission_prompt\|idle_prompt\|auth_success\|elicitation_dialog\|elicitation_complete\|elicitation_response\|agent_needs_input\|agent_completed` |
 | MessageDisplay | No | — |
 | SubagentStart | No | agent_type |
 | SubagentStop | Yes (exit 2) | agent_type |
@@ -75,7 +75,7 @@
 | TeammateIdle | Yes (exit 2) | — |
 | ConfigChange | Yes (exit 2) | source |
 | CwdChanged | No | — |
-| DirectoryAdded | No | — |
+| DirectoryAdded | No | addition method: `slash_command\|register_repo_root` |
 | FileChanged | No | filename (basename) |
 | WorktreeCreate | Yes (exit 2) | — |
 | WorktreeRemove | No | — |
@@ -166,7 +166,7 @@
 
 - `message`: string
 - `title`: string (optional)
-- `notification_type`: `permission_prompt|idle_prompt|auth_success|elicitation_dialog|elicitation_complete|elicitation_response`
+- `notification_type`: `permission_prompt|idle_prompt|auth_success|elicitation_dialog|elicitation_complete|elicitation_response|agent_needs_input|agent_completed`
 - `notification_data`: object (optional)
 
 ### SubagentStart / SubagentStop
@@ -326,6 +326,7 @@
 - `hookSpecificOutput.decision.behavior`: `allow|deny`
 - `hookSpecificOutput.decision.updatedInput`: object
 - `hookSpecificOutput.decision.permissionRules`: array of rule strings
+- `hookSpecificOutput.decision.saveRule`: `{ "rule": "Edit(*.ts)", "mode": "allow" }` (optional, persists rule to settings)
 
 ### PermissionDenied
 

--- a/docs/upstream-specs/copilot.md
+++ b/docs/upstream-specs/copilot.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Hooks Specification
 
 > Source: https://docs.github.com/en/copilot/reference/hooks-configuration
-> Snapshot: 2026-08-04
+> Snapshot: 2026-08-11
 
 ## Config Location
 
@@ -71,16 +71,16 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pos
 
 | Event | Has Output | Description |
 |-------|-----------|-------------|
-| sessionStart | No | New or resumed session begins |
+| sessionStart | Yes | New or resumed session begins; can inject `additionalContext` |
 | sessionEnd | No | Session completes or terminates |
-| userPromptSubmitted | No | User submits a prompt |
+| userPromptSubmitted | Yes | User submits a prompt; can return `modifiedPrompt` (SDK hooks only) |
 | userPromptTransformed | Yes | After prompt transformation, before model receives it |
 | preToolUse | Yes | Before tool execution (can deny) |
 | postToolUse | Yes | After tool execution (can modify result) |
-| postToolUseFailure | No | After a tool completes with a failure |
+| postToolUseFailure | Yes | After a tool completes with a failure; can return `additionalContext` |
 | errorOccurred | No | Error during execution |
-| agentStop | Yes | Main agent finishes a turn (can block) |
-| notification | No | Async system notification (CLI only) |
+| agentStop | Yes | Main agent finishes a turn (can block; 8-consecutive-block runaway guard) |
+| notification | Yes | Async system notification (CLI only); can return `additionalContext` |
 | permissionRequest | Yes | Before permission service runs (CLI only) |
 | preCompact | No | Context compaction is about to begin |
 | subagentStart | Yes | A subagent is spawned; can inject context (cannot block) |
@@ -97,6 +97,13 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pos
   "cwd": "string",
   "source": "new|resume|startup",
   "initialPrompt": "string"
+}
+```
+
+Output:
+```json
+{
+  "additionalContext": "string (optional, injected into session)"
 }
 ```
 
@@ -119,6 +126,13 @@ Optional regex patterns supported for: `notification`, `permissionRequest`, `pos
   "timestamp": "number (Unix ms)",
   "cwd": "string",
   "prompt": "string"
+}
+```
+
+Output (SDK programmatic hooks only; command/HTTP hooks output is dropped):
+```json
+{
+  "modifiedPrompt": "string"
 }
 ```
 
@@ -179,6 +193,13 @@ Output:
   "toolName": "string",
   "toolArgs": "string (JSON-stringified)",
   "error": "string"
+}
+```
+
+Output:
+```json
+{
+  "additionalContext": "string (optional, recovery guidance for the model)"
 }
 ```
 
@@ -267,6 +288,13 @@ Output:
   "message": "string",
   "title": "string (optional)",
   "notification_type": "shell_completed|shell_detached_completed|agent_completed|agent_idle|permission_prompt|elicitation_dialog"
+}
+```
+
+Output:
+```json
+{
+  "additionalContext": "string (optional, injected as user message)"
 }
 ```
 
@@ -383,9 +411,12 @@ Note: only `deny` is processed.
 
 ## Constraints
 
-- Default timeout: 30 seconds
+- Default timeout: 30 seconds (`timeoutSec`; the `timeout` field is a deprecated alias)
 - Multiple hooks of same type execute sequentially
 - Scripts read JSON from stdin
 - `disableAllHooks: true` disables all hooks in a file
 - `transcriptPath` now included in `agentStop`, `subagentStart`, `subagentStop`, `preCompact`
 - `preToolUse` is **fail-closed**: crashes, non-zero exits (other than 2), and timeouts all deny the tool call
+- **Runaway guard**: After 8 consecutive `block` decisions from `agentStop`, the CLI overrides and ends the turn
+- Hook output bounded at **10 MiB** per invocation; `additionalContext` capped at **10 KB** when multiple hooks return it
+- HTTP hooks require HTTPS by default for permission events; HTTP allowed for localhost only with `COPILOT_HOOK_ALLOW_LOCALHOST=1`


### PR DESCRIPTION
## Summary

Upstream documentation sync performed on 2026-08-11. Two tools had changes detected.

### Claude Code ([code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks))

- **Notification**: Added `agent_needs_input` and `agent_completed` to the list of `notification_type` values (matcher targets and per-event field)
- **DirectoryAdded**: Documented matcher targets (`slash_command|register_repo_root`); previously shown as `—`
- **PermissionRequest output**: Added `saveRule` field (`{ "rule": "Edit(*.ts)", "mode": "allow" }`) for persisting permission rules to settings

### GitHub Copilot ([docs.github.com/en/copilot/reference/hooks-configuration](https://docs.github.com/en/copilot/reference/hooks-configuration))

- **sessionStart**: Now documented as having output — can return `additionalContext` injected into session
- **userPromptSubmitted**: Now documented as having output — `modifiedPrompt` (honored by SDK programmatic hooks only; command/HTTP output is dropped)
- **postToolUseFailure**: Now documented as having output — `additionalContext` for recovery guidance
- **notification**: Now documented as having output — `additionalContext` injected as user message
- **agentStop**: Added runaway guard note (CLI overrides after 8 consecutive `block` decisions)
- **Constraints**: Added 10 MiB hook output cap, 10 KB `additionalContext` cap, HTTP/HTTPS localhost constraint, and note that `timeout` is a deprecated alias for `timeoutSec`

### No changes detected

Cursor, Codex, OpenCode, Gemini, Cline, Kiro — all match their existing snapshots.

### Implementation

No `hook_event.py` or tool `.py` changes required — the upstream changes are output-side schema clarifications, not new events or detection fields.

All 132 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT6mriqCpu5Cm4iC1beWPN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Claude仕様のスナップショットを更新しました。
  * 通知イベントやディレクトリ追加時の matcher 仕様を拡充しました。
  * 権限リクエストでルールを保存するオプションを追加しました。
  * GitHub Copilot Hooks仕様を更新し、各イベントの出力内容や制約を明確化しました。
  * タイムアウト、出力サイズ、HTTPS要件などの制限事項を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->